### PR TITLE
tsbalancing no longer changes error option

### DIFF
--- a/R/tsbalancing.R
+++ b/R/tsbalancing.R
@@ -3,19 +3,19 @@
 #'
 #' @description
 #'
-#' \if{html,text}{(\emph{version française: 
+#' \if{html,text}{(\emph{version française:
 #' \url{https://StatCan.github.io/gensol-gseries/fr/reference/tsbalancing.html}})}
-#' 
+#'
 #' _Replication of the G-Series 2.0 SAS\eqn{^\circledR}{®} ***GSeriesTSBalancing*** macro. See the
 #' G-Series 2.0 documentation for details (Statistics Canada 2016)._
 #'
-#' This function balances (reconciles) a system of time series according to a set of linear constraints. The balancing 
-#' solution is obtained by solving one or several quadratic minimization problems (see section **Details**) with the OSQP 
-#' solver (Stellato et al. 2020). Given the feasibility of the balancing problem(s), the resulting time series data respect 
-#' the specified constraints for every time period. Linear equality and inequality constraints are allowed. Optionally, the 
+#' This function balances (reconciles) a system of time series according to a set of linear constraints. The balancing
+#' solution is obtained by solving one or several quadratic minimization problems (see section **Details**) with the OSQP
+#' solver (Stellato et al. 2020). Given the feasibility of the balancing problem(s), the resulting time series data respect
+#' the specified constraints for every time period. Linear equality and inequality constraints are allowed. Optionally, the
 #' preservation of temporal totals may also be specified.
-#' 
-#' 
+#'
+#'
 #' @usage
 #' tsbalancing(
 #'   in_ts,
@@ -41,42 +41,42 @@
 #'   validation_only = FALSE,
 #'   quiet = FALSE
 #' )
-#' 
 #'
-#' @param in_ts (mandatory) 
-#' 
-#' Time series (object of class "ts" or "mts") that contains the time series data to be reconciled. 
+#'
+#' @param in_ts (mandatory)
+#'
+#' Time series (object of class "ts" or "mts") that contains the time series data to be reconciled.
 #' They are the balancing problems' input data (initial solutions).
-#' 
-#' @param problem_specs_df (mandatory) 
-#' 
-#' Balancing problem specifications data frame (object of class "data.frame"). Using a sparse format inspired from the 
-#' SAS/OR\eqn{^\circledR}{®} LP procedure’s *sparse data input format* (SAS Institute 2015), it contains only the relevant 
-#' information such as the nonzero coefficients of the balancing constraints as well as the non-default alterability 
-#' coefficients and lower/upper bounds (i.e., values that would take precedence over those defined with arguments `alter_pos`, 
+#'
+#' @param problem_specs_df (mandatory)
+#'
+#' Balancing problem specifications data frame (object of class "data.frame"). Using a sparse format inspired from the
+#' SAS/OR\eqn{^\circledR}{®} LP procedure’s *sparse data input format* (SAS Institute 2015), it contains only the relevant
+#' information such as the nonzero coefficients of the balancing constraints as well as the non-default alterability
+#' coefficients and lower/upper bounds (i.e., values that would take precedence over those defined with arguments `alter_pos`,
 #' `alter_neg`, `alter_mix`, `alter_temporal`, `lower_bound` and `upper_bound`).
-#' 
-#' The information is provided using four mandatory variables (`type`, `col`, `row` and `coef`) and one optional variable 
-#' (`timeVal`). An observation (a row) in the problem specs data frame either defines a label for one of the seven types of the 
-#' balancing problem elements with columns `type` and `row` (see *Label definition records* below) or specifies coefficients 
-#' (numerical values) for those balancing problem elements with variables `col`, `row`, `coef` and `timeVal` (see *Information 
+#'
+#' The information is provided using four mandatory variables (`type`, `col`, `row` and `coef`) and one optional variable
+#' (`timeVal`). An observation (a row) in the problem specs data frame either defines a label for one of the seven types of the
+#' balancing problem elements with columns `type` and `row` (see *Label definition records* below) or specifies coefficients
+#' (numerical values) for those balancing problem elements with variables `col`, `row`, `coef` and `timeVal` (see *Information
 #' specification records* below).
-#' 
+#'
 #' * **Label definition records** (`type` is not missing (is not `NA`))
-#' 
-#'   * `type` (chr): reserved keyword identifying the type of problem element being defined: 
+#'
+#'   * `type` (chr): reserved keyword identifying the type of problem element being defined:
 #'     * `EQ`: equality (\eqn{=}) balancing constraint
 #'     * `LE`: lower or equal (\eqn{\le}{<=}) balancing constraint
-#'     * `GE`: greater or equal (\eqn{\ge}{>=}) balancing constraint 
+#'     * `GE`: greater or equal (\eqn{\ge}{>=}) balancing constraint
 #'     * `lowerBd`: period value lower bound
 #'     * `upperBd`: period value upper bound
 #'     * `alter`: period values alterability coefficient
 #'     * `alterTmp`: temporal total alterability coefficient
 #'   * `row` (chr): label to be associated to the problem element (_`type` keyword_)
 #'   * _all other variables are irrelevant and should contain missing data (`NA` values)_ \cr \cr
-#' 
+#'
 #' * **Information specification records** (`type` is missing (is `NA`))
-#' 
+#'
 #'   * `type` (chr): not applicable (`NA`)
 #'   * `col` (chr): series name or reserved word `_rhs_` to specify a balancing constraint right-hand side (RHS) value.
 #'   * `row` (chr): problem element label.
@@ -84,23 +84,23 @@
 #'     * balancing constraint series coefficient or RHS value
 #'     * series period value lower or upper bound
 #'     * series period value or temporal total alterability coefficient
-#'   * `timeVal` (num): optional time value to restrict the application of series bounds or alterability coefficients 
-#'   to a specific time period (or temporal group). It corresponds to the time value, as returned by `stats::time()`, of a given 
-#'   input time series (argument `in_ts`) period (observation) and is conceptually equivalent to \eqn{year + (period - 1) / 
+#'   * `timeVal` (num): optional time value to restrict the application of series bounds or alterability coefficients
+#'   to a specific time period (or temporal group). It corresponds to the time value, as returned by `stats::time()`, of a given
+#'   input time series (argument `in_ts`) period (observation) and is conceptually equivalent to \eqn{year + (period - 1) /
 #'   frequency}.
 #'
-#' Note that empty strings (`""` or `''`) for character variables are interpreted as missing (`NA`) by the function. Variable 
-#' `row` identifies the elements of the balancing problem and is the key variable that makes the link between both types of 
-#' records. The same label (`row`) cannot be associated with more than one type of problem element (`type`) and multiple labels 
-#' (`row`) cannot be defined for the same given type of problem element (`type`), except for balancing constraints (values 
+#' Note that empty strings (`""` or `''`) for character variables are interpreted as missing (`NA`) by the function. Variable
+#' `row` identifies the elements of the balancing problem and is the key variable that makes the link between both types of
+#' records. The same label (`row`) cannot be associated with more than one type of problem element (`type`) and multiple labels
+#' (`row`) cannot be defined for the same given type of problem element (`type`), except for balancing constraints (values
 #' `"EQ"`, `"LE"` and `"GE"` of column `type`). User-friendly features of the problem specs data frame include:
 #' * The order of the observations (rows) is not important.
-#' * Character values (variables `type`, `row` and `col`) are not case sensitive (e.g., strings `"Constraint 1"` and 
-#' `"CONSTRAINT 1"` for `row` would be considered as the same problem element label), except when `col` is used to specify a 
+#' * Character values (variables `type`, `row` and `col`) are not case sensitive (e.g., strings `"Constraint 1"` and
+#' `"CONSTRAINT 1"` for `row` would be considered as the same problem element label), except when `col` is used to specify a
 #' series name (a column of the input time series object) where **case sensitivity is enforced**.
-#' * The variable names of the problem specs data frame are also not case sensitive (e.g., `type`, `Type` or `TYPE` are all 
+#' * The variable names of the problem specs data frame are also not case sensitive (e.g., `type`, `Type` or `TYPE` are all
 #' valid) and `time_val` is an accepted variable name (instead of `timeVal`).
-#' 
+#'
 #' Finally, the following table lists valid aliases for the *`type` keywords* (type of problem element):
 #' | **Keyword** | **Aliases** |
 #' |:-----------:|:------------|
@@ -110,9 +110,9 @@
 #' | `lowerBd`   | `lowerBound`, `lowerBnd`, + *same terms with '_', '.' or ' ' between words*|
 #' | `upperBd`   | `upperBound`, `upperBnd`, + *same terms with '_', '.' or ' ' between words*|
 #' | `alterTmp`  | `alterTemporal`, `alterTemp`, + *same terms with '_', '.' or ' ' between words*|
-#' 
+#'
 #' Reviewing the **Examples** should help conceptualize the balancing problem specifications data frame.
-#' 
+#'
 #' @param temporal_grp_periodicity (optional)
 #'
 #' Positive integer defining the number of periods in temporal groups for which the totals should be preserved.
@@ -132,26 +132,26 @@
 #' for period-by-period processing without temporal total preservation (`temporal_grp_periodicity = 1`).
 #'
 #' **Default value** is `temporal_grp_start = 1`.
-#' 
+#'
 #' @param osqp_settings_df (optional)
-#' 
-#' Data frame (object of class "data.frame") containing a sequence of OSQP settings for solving the balancing problems. 
+#'
+#' Data frame (object of class "data.frame") containing a sequence of OSQP settings for solving the balancing problems.
 #' The package includes two predefined OSQP settings sequence data frames:
 #' * [default_osqp_sequence]: fast and effective (default);
 #' * [alternate_osqp_sequence]: geared towards precision at the expense of execution time.
-#' 
-#' See `vignette("osqp-settings-sequence-dataframe")` for more details on this topic and to see the actual contents 
-#' of these two data frames. Note that the concept of a *solving sequence* with different sets of solver settings is 
+#'
+#' See `vignette("osqp-settings-sequence-dataframe")` for more details on this topic and to see the actual contents
+#' of these two data frames. Note that the concept of a *solving sequence* with different sets of solver settings is
 #' new in G-Series 3.0 (a single solving attempt was made in G-Series 2.0).
 #'
 #' **Default value** is `osqp_settings_df = default_osqp_sequence`.
-#' 
+#'
 #' @param display_level (optional)
-#' 
-#' Integer in the \[0 .. 3\] interval specifying the level of information to display in the console (`stdout()`). 
+#'
+#' Integer in the \[0 .. 3\] interval specifying the level of information to display in the console (`stdout()`).
 #' Note that specifying argument `quiet = TRUE` would *nullify* argument `display_level` (none of the following information
 #' would be displayed).
-#' 
+#'
 #' | **Displayed information**                           |       **`0`**       |       **`1`**       |       **`2`**       |       **`3`**       |
 #' |:----------------------------------------------------|:-------------------:|:-------------------:|:-------------------:|:-------------------:|
 #' | Function header                                     | \eqn{\checkmark}{Y} | \eqn{\checkmark}{Y} | \eqn{\checkmark}{Y} | \eqn{\checkmark}{Y} |
@@ -160,159 +160,159 @@
 #' | Individual problem results (values and constraints) |                     |                     |                     | \eqn{\checkmark}{Y} |
 #'
 #' **Default value** is `display_level = 1`.
-#'  
+#'
 #' @param alter_pos (optional)
-#' 
-#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with **positive** 
-#' coefficients in all balancing constraints in which they are involved (e.g., component series in aggregation table raking problems). 
+#'
+#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with **positive**
+#' coefficients in all balancing constraints in which they are involved (e.g., component series in aggregation table raking problems).
 #' Alterability coefficients provided in the problem specification data frame (argument `problem_specs_df`) override this value.
 #'
 #' **Default value** is `alter_pos = 1.0` (nonbinding values).
-#' 
+#'
 #' @param alter_neg (optional)
-#' 
-#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with **negative** 
-#' coefficients in all balancing constraints in which they are involved (e.g., marginal totals in aggregation table raking problems). 
+#'
+#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with **negative**
+#' coefficients in all balancing constraints in which they are involved (e.g., marginal totals in aggregation table raking problems).
 #' Alterability coefficients provided in the problem specification data frame (argument `problem_specs_df`) override this value.
 #'
 #' **Default value** is `alter_neg = 1.0` (nonbinding values).
-#' 
+#'
 #' @param alter_mix (optional)
-#' 
-#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with a mix of 
-#' **positive and negative** coefficients in the balancing constraints in which they are involved. Alterability coefficients provided 
+#'
+#' Nonnegative real number specifying the default alterability coefficient associated to the values of time series with a mix of
+#' **positive and negative** coefficients in the balancing constraints in which they are involved. Alterability coefficients provided
 #' in the problem specification data frame (argument `problem_specs_df`) override this value.
 #'
 #' **Default value** is `alter_mix = 1.0` (nonbinding values).
-#' 
+#'
 #' @param alter_temporal (optional)
-#' 
-#' Nonnegative real number specifying the default alterability coefficient associated to the time series temporal totals. 
+#'
+#' Nonnegative real number specifying the default alterability coefficient associated to the time series temporal totals.
 #' Alterability coefficients provided in the problem specification data frame (argument `problem_specs_df`) override this value.
 #'
 #' **Default value** is `alter_temporal = 0.0` (binding values).
-#' 
+#'
 #' @param lower_bound (optional)
-#' 
-#' Real number specifying the default lower bound for the time series values. Lower bounds provided in the problem specification 
+#'
+#' Real number specifying the default lower bound for the time series values. Lower bounds provided in the problem specification
 #' data frame (argument \ifelse{latex}{\code{problem _specs_df}}{\code{problem_specs_df}}) override this value.
 #'
 #' **Default value** is `lower_bound = -Inf` (unbounded).
-#' 
+#'
 #' @param upper_bound (optional)
-#' 
-#' Real number specifying the default upper bound for the time series values. Upper bounds provided in the problem specification 
+#'
+#' Real number specifying the default upper bound for the time series values. Upper bounds provided in the problem specification
 #' data frame (argument \ifelse{latex}{\code{problem _specs_df}}{\code{problem_specs_df}}) override this value.
 #'
 #' **Default value** is `upper_bound = Inf` (unbounded).
-#' 
+#'
 #' @param tolV (optional)
-#' 
-#' Nonnegative real number specifying the tolerance, in absolute value, for the balancing constraints right-hand side (RHS) 
+#'
+#' Nonnegative real number specifying the tolerance, in absolute value, for the balancing constraints right-hand side (RHS)
 #' values:
-#' * `EQ` constraints: \eqn{\quad A\mathbf{x} = \mathbf{b} \quad}{Ax = b} become \eqn{\quad \mathbf{b} - \epsilon \le A\mathbf{x} 
+#' * `EQ` constraints: \eqn{\quad A\mathbf{x} = \mathbf{b} \quad}{Ax = b} become \eqn{\quad \mathbf{b} - \epsilon \le A\mathbf{x}
 #' \le \mathbf{b} + \epsilon}{b - eps <= Ax <= b + eps}
-#' * `LE` constraints: \eqn{\quad A\mathbf{x} \le \mathbf{b} \quad}{Ax <= b} become \eqn{\quad A\mathbf{x} \le \mathbf{b} + 
+#' * `LE` constraints: \eqn{\quad A\mathbf{x} \le \mathbf{b} \quad}{Ax <= b} become \eqn{\quad A\mathbf{x} \le \mathbf{b} +
 #' \epsilon}{Ax <= b + eps}
-#' * `GE` constraints: \eqn{\quad A\mathbf{x} \ge \mathbf{b} \quad}{Ax >= b} become \eqn{\quad A\mathbf{x} \ge \mathbf{b} - 
+#' * `GE` constraints: \eqn{\quad A\mathbf{x} \ge \mathbf{b} \quad}{Ax >= b} become \eqn{\quad A\mathbf{x} \ge \mathbf{b} -
 #' \epsilon}{Ax >= b - eps}
-#' 
-#' where \eqn{\epsilon}{eps} is the tolerance specified with `tolV`. This argument does not apply to the *period value (lower 
-#' and upper) bounds* specified with arguments `lower_bound` and `upper_bound` or in the problem specs data frame (argument 
-#' `prob_specs_df`). I.e., `tolV` does not affect the time series values lower and upper bounds, unless they are specified as 
+#'
+#' where \eqn{\epsilon}{eps} is the tolerance specified with `tolV`. This argument does not apply to the *period value (lower
+#' and upper) bounds* specified with arguments `lower_bound` and `upper_bound` or in the problem specs data frame (argument
+#' `prob_specs_df`). I.e., `tolV` does not affect the time series values lower and upper bounds, unless they are specified as
 #' *balancing constraints* instead (with `GE` and `LE` constraints in the problem specs data frame).
-#' 
+#'
 #' **Default value** is `tolV = 0.0` (no tolerance).
-#' 
+#'
 #' @param tolV_temporal,tolP_temporal (optional)
-#' 
-#' Nonnegative real number, or `NA`, specifying the tolerance, in percentage (`tolP_temporal`) or absolute value 
-#' (`tolV_temporal`), for the implicit temporal aggregation constraints associated to **binding temporal totals** 
+#'
+#' Nonnegative real number, or `NA`, specifying the tolerance, in percentage (`tolP_temporal`) or absolute value
+#' (`tolV_temporal`), for the implicit temporal aggregation constraints associated to **binding temporal totals**
 #' \eqn{\left( \sum_t{x_{i,t}} = \sum_t{y_{i,t}} \right)}{(sum_t{x_{i,t}} = sum_t{y_{i,t}})}, which become:
-#' \deqn{\sum_t{y_{i,t}} - \epsilon_\text{abs} \le \sum_t{x_{i,t}} \le \sum_t{y_{i,t}} + \epsilon_\text{abs}}{sum_t{y_{i,t}} - 
+#' \deqn{\sum_t{y_{i,t}} - \epsilon_\text{abs} \le \sum_t{x_{i,t}} \le \sum_t{y_{i,t}} + \epsilon_\text{abs}}{sum_t{y_{i,t}} -
 #' eps_abs <= sum_t{x_{i,t}} <= sum_t{y_{i,t}} + eps_abs}
-#' or 
-#' \deqn{\sum_t{y_{i,t}} \left( 1 - \epsilon_\text{rel} \right) \le \sum_t{x_{i,t}} \le \sum_t{y_{i,t}} \left( 1 + 
+#' or
+#' \deqn{\sum_t{y_{i,t}} \left( 1 - \epsilon_\text{rel} \right) \le \sum_t{x_{i,t}} \le \sum_t{y_{i,t}} \left( 1 +
 #' \epsilon_\text{rel} \right)}{sum_t{y_{i,t}} (1 - eps_rel) <= sum_t{x_{i,t}} <= sum_t{y_{i,t}} (1 + eps_rel)}
-#' 
-#' where \eqn{\epsilon_\text{abs}}{eps_abs} and \eqn{\epsilon_\text{rel}}{eps_rel} are the absolute and percentage tolerances 
-#' specified respectively with `tolV_temporal` and  `tolP_temporal`. Both arguments cannot be specified together (one must be 
+#'
+#' where \eqn{\epsilon_\text{abs}}{eps_abs} and \eqn{\epsilon_\text{rel}}{eps_rel} are the absolute and percentage tolerances
+#' specified respectively with `tolV_temporal` and  `tolP_temporal`. Both arguments cannot be specified together (one must be
 #' specified while the other must be `NA`).
 #'
 #' **Example:** to set a tolerance of 10 *units*, specify \ifelse{latex}{\code{tolV_temporal = 10, tolP_temporal} \code{= NA}}{
-#' \code{tolV_temporal = 10, tolP_temporal = NA}}; to set a tolerance of 1%, specify`tolV_temporal = NA, tolP_temporal = 0.01`. 
-#' 
+#' \code{tolV_temporal = 10, tolP_temporal = NA}}; to set a tolerance of 1%, specify`tolV_temporal = NA, tolP_temporal = 0.01`.
+#'
 #' **Default values** are `tolV_temporal = 0.0` and `tolP_temporal = NA` (no tolerance).
-#' 
+#'
 #' @param validation_tol (optional)
-#' 
-#' Nonnegative real number specifying the tolerance for the validation of the balancing results. The function verifies if 
-#' the final (reconciled) time series values meet the constraints, allowing for discrepancies up to the value specified with 
+#'
+#' Nonnegative real number specifying the tolerance for the validation of the balancing results. The function verifies if
+#' the final (reconciled) time series values meet the constraints, allowing for discrepancies up to the value specified with
 #' this argument. A warning is issued as soon as one constraint is not met (discrepancy greater than `validation_tol`).
-#' 
-#' With constraints defined as \eqn{\mathbf{l} \le A\mathbf{x} \le \mathbf{u}}{l <= Ax <= u}, where \eqn{\mathbf{l = u}}{l = u} 
-#' for `EQ` constraints, \eqn{\mathbf{l} = -\infty}{l = -Inf} for `LE` constraints and \eqn{\mathbf{u} = \infty}{u = Inf} for 
-#' `GE` constraints, **constraint discrepancies** correspond to \eqn{\max \left( 0, \mathbf{l} - A\mathbf{x}, A\mathbf{x} - 
-#' \mathbf{u} \right)}{max(0, l - Ax, Ax - u)}, where constraint bounds \eqn{\mathbf{l}}{l} and \eqn{\mathbf{u}}{u} include 
-#' the tolerances, when applicable, specified with arguments `tolV`, `tolV_temporal` and `tolP_temporal`.  
-#' 
+#'
+#' With constraints defined as \eqn{\mathbf{l} \le A\mathbf{x} \le \mathbf{u}}{l <= Ax <= u}, where \eqn{\mathbf{l = u}}{l = u}
+#' for `EQ` constraints, \eqn{\mathbf{l} = -\infty}{l = -Inf} for `LE` constraints and \eqn{\mathbf{u} = \infty}{u = Inf} for
+#' `GE` constraints, **constraint discrepancies** correspond to \eqn{\max \left( 0, \mathbf{l} - A\mathbf{x}, A\mathbf{x} -
+#' \mathbf{u} \right)}{max(0, l - Ax, Ax - u)}, where constraint bounds \eqn{\mathbf{l}}{l} and \eqn{\mathbf{u}}{u} include
+#' the tolerances, when applicable, specified with arguments `tolV`, `tolV_temporal` and `tolP_temporal`.
+#'
 #' **Default value** is `validation_tol = 0.001`.
-#' 
+#'
 #' @param trunc_to_zero_tol (optional)
-#' 
-#' Nonnegative real number specifying the tolerance, in absolute value, for replacing by zero (small) values in the output 
-#' (reconciled) time series data (output object `out_ts`). Specify `trunc_to_zero_tol = 0` to disable this *truncation to zero* 
-#' process on the reconciled data. Otherwise, specify `trunc_to_zero_tol > 0` to replace with \eqn{0.0} any value in the 
-#' \eqn{\left[ -\epsilon, \epsilon \right]}{[-eps, eps]} interval, where \eqn{\epsilon}{eps} is the tolerance specified with 
-#' `trunc_to_zero_tol`. 
-#' 
-#' Note that the final constraint discrepancies (see argument `validation_tol`) are calculated on the *zero truncated* 
-#' reconciled time series values, therefore ensuring accurate validation of the actual reconciled data returned by the 
+#'
+#' Nonnegative real number specifying the tolerance, in absolute value, for replacing by zero (small) values in the output
+#' (reconciled) time series data (output object `out_ts`). Specify `trunc_to_zero_tol = 0` to disable this *truncation to zero*
+#' process on the reconciled data. Otherwise, specify `trunc_to_zero_tol > 0` to replace with \eqn{0.0} any value in the
+#' \eqn{\left[ -\epsilon, \epsilon \right]}{[-eps, eps]} interval, where \eqn{\epsilon}{eps} is the tolerance specified with
+#' `trunc_to_zero_tol`.
+#'
+#' Note that the final constraint discrepancies (see argument `validation_tol`) are calculated on the *zero truncated*
+#' reconciled time series values, therefore ensuring accurate validation of the actual reconciled data returned by the
 #' function.
-#' 
+#'
 #' **Default value** is `trunc_to_zero_tol = validation_tol`.
-#' 
+#'
 #' @param full_sequence (optional)
-#' 
-#' Logical argument specifying whether all the steps of the *OSQP settings sequence data frame* should be performed or not. 
+#'
+#' Logical argument specifying whether all the steps of the *OSQP settings sequence data frame* should be performed or not.
 #' See argument `osqp_settings_df` and `vignette("osqp-settings-sequence-dataframe")` for more details on this topic.
-#' 
+#'
 #' **Default value** is `full_sequence = FALSE`.
-#' 
+#'
 #' @param validation_only (optional)
-#' 
-#' Logical argument specifying whether the function should only perform input data validation or not. When 
-#' `validation_only = TRUE`, the specified *balancing constraints* and *period value (lower and upper) bounds* constraints 
-#' are validated against the input time series data, allowing for discrepancies up to the value specified with argument 
-#' `validation_tol`. Otherwise, when `validation_only = FALSE` (default), the input data are first reconciled and the 
+#'
+#' Logical argument specifying whether the function should only perform input data validation or not. When
+#' `validation_only = TRUE`, the specified *balancing constraints* and *period value (lower and upper) bounds* constraints
+#' are validated against the input time series data, allowing for discrepancies up to the value specified with argument
+#' `validation_tol`. Otherwise, when `validation_only = FALSE` (default), the input data are first reconciled and the
 #' resulting (output) data are then validated.
-#' 
+#'
 #' **Default value** is `validation_only = FALSE`.
-#' 
+#'
 #' @param quiet (optional)
-#' 
-#' Logical argument specifying whether or not to display only essential information such as warnings, errors and the period 
-#' (or set of periods) being reconciled. You could further suppress, if desired, the display of the _balancing period(s)_ 
-#' information by _wrapping_ your [tsbalancing()] call with [suppressMessages()]. In that case, the `proc_grp_df` output 
-#' data frame can be used to identify (unsuccessful) balancing problems associated with warning messages (if any). Note that 
+#'
+#' Logical argument specifying whether or not to display only essential information such as warnings, errors and the period
+#' (or set of periods) being reconciled. You could further suppress, if desired, the display of the _balancing period(s)_
+#' information by _wrapping_ your [tsbalancing()] call with [suppressMessages()]. In that case, the `proc_grp_df` output
+#' data frame can be used to identify (unsuccessful) balancing problems associated with warning messages (if any). Note that
 #' specifying `quiet = TRUE` would also *nullify* argument `display_level`.
 #'
 #' **Default value** is `quiet = FALSE`.
-#'   
 #'
-#' @details 
-#' This function solves one balancing problem per processing group (see section **Processing groups** for details). Each of these balancing 
+#'
+#' @details
+#' This function solves one balancing problem per processing group (see section **Processing groups** for details). Each of these balancing
 #' problems is a quadratic minimization problem of the following form:
-#' \deqn{\displaystyle 
+#' \deqn{\displaystyle
 #' \begin{aligned}
-#' & \underset{\mathbf{x}}{\text{minimize}} 
+#' & \underset{\mathbf{x}}{\text{minimize}}
 #' & & \mathbf{\left( y - x \right)}^{\mathrm{T}} W \mathbf{\left( y - x \right)} \\
-#' & \text{subject to} 
+#' & \text{subject to}
 #' & & \mathbf{l} \le A \mathbf{x} \le \mathbf{u}
 #' \end{aligned}
 #' }{min(x) (y - x)' W (y - x), subject to l <= Ax <= u}
 #' where
-#' - \eqn{\mathbf{y}}{y} is the vector of the initial problem values, i.e., the initial time series period values and, when applicable, 
+#' - \eqn{\mathbf{y}}{y} is the vector of the initial problem values, i.e., the initial time series period values and, when applicable,
 #' temporal totals;
 #' - \eqn{\mathbf{x}}{x} is the final (reconciled) version of vector \eqn{\mathbf{y}}{y};
 #' - matrix \eqn{W = \mathrm{diag} \left( \mathbf{w} \right)}{W = diag(w)} with vector \eqn{\mathbf{w}}{w} elements \eqn{w_i = \left\{
@@ -320,173 +320,173 @@
 #'       0 & \text{if } |c_i y_i| = 0 \\
 #'       \frac{1}{|c_i y_i|} & \text{otherwise}
 #'     \end{array} \right.
-#'     }{w_i = 0 if |c_i y_i| = 0, w_i = 1/|c_i y_i| otherwise}, 
-#'     where \eqn{c_i} is the alterability coefficient of problem value \eqn{y_i} and cases corresponding to \eqn{|c_i y_i| 
+#'     }{w_i = 0 if |c_i y_i| = 0, w_i = 1/|c_i y_i| otherwise},
+#'     where \eqn{c_i} is the alterability coefficient of problem value \eqn{y_i} and cases corresponding to \eqn{|c_i y_i|
 #'     = 0} are fixed problem values (binding period values or temporal totals);
-#' - matrix \eqn{A} and vectors \eqn{\mathbf{l}}{l} and \eqn{\mathbf{u}}{u} specify the _balancing constraints_, the _implicit 
-#' temporal total aggregation constraints_ (when applicable), the _period value (upper and lower) bounds_ as well as _\eqn{x_i 
+#' - matrix \eqn{A} and vectors \eqn{\mathbf{l}}{l} and \eqn{\mathbf{u}}{u} specify the _balancing constraints_, the _implicit
+#' temporal total aggregation constraints_ (when applicable), the _period value (upper and lower) bounds_ as well as _\eqn{x_i
 #' = y_i} constraints for fixed \eqn{y_i} values_ \eqn{\left( \left| c_i y_i \right| = 0 \right)}{(|c_i y_i| = 0)}.
 #'
-#' In practice, the objective function of the problem solved by OSQP excludes constant term \eqn{\mathbf{y}^{\mathrm{T}} W 
-#' \mathbf{y}}{y' W y}, therefore corresponding to \eqn{\mathbf{x}^{\mathrm{T}} W \mathbf{x} - 2 \left( \mathbf{w} \mathbf{y} 
-#' \right)^{\mathrm{T}} \mathbf{x}}{x' W x - 2 (w y)' x}, and the fixed \eqn{y_i} values \eqn{\left( \left| c_i y_i \right| = 0 
+#' In practice, the objective function of the problem solved by OSQP excludes constant term \eqn{\mathbf{y}^{\mathrm{T}} W
+#' \mathbf{y}}{y' W y}, therefore corresponding to \eqn{\mathbf{x}^{\mathrm{T}} W \mathbf{x} - 2 \left( \mathbf{w} \mathbf{y}
+#' \right)^{\mathrm{T}} \mathbf{x}}{x' W x - 2 (w y)' x}, and the fixed \eqn{y_i} values \eqn{\left( \left| c_i y_i \right| = 0
 #' \right)}{(|c_i y_i| = 0)} are removed from the problem, adjusting the constraints accordingly, i.e.:
 #' - rows corresponding to the *\eqn{x_i = y_i} constraints for fixed \eqn{y_i} values* are removed from \eqn{A}, \eqn{
 #' \mathbf{l}}{l} and \eqn{\mathbf{u}}{u};
 #' - columns corresponding to fixed \eqn{y_i} values are removed from \eqn{A} while appropriately adjusting \eqn{
 #' \mathbf{l}}{l} and \eqn{\mathbf{u}}{u}.
-#'     
-#'     
+#'
+#'
 ######
-# This subsection differs slightly between `tsraking()` and `tsbalancing` and is therefore maintained for both functions 
+# This subsection differs slightly between `tsraking()` and `tsbalancing` and is therefore maintained for both functions
 # (in both sets of roxygen2 comments) as opposed to being shared with `roxygen2 tag `@inheritSection`.
 # => the "Temporal total preservation* paragraph is the SAME, however: keep them "in sync"!.
 ######
 #' ## Alterability Coefficients
-#' Alterability coefficients are nonnegative numbers that change the relative cost of modifying an initial problem value. 
-#' By changing the actual objective function to minimize, they allow the generation of a wide range of solutions. Since they 
-#' appear in the denominator of the objective function (matrix \eqn{W}), the larger the alterability coefficient the less costly 
-#' it is to modify a problem value (period value or temporal total) and, conversely, the smaller the alterability coefficient 
-#' the more costly it becomes. This results in problem values with larger alterability coefficients proportionally changing more 
-#' than the ones with smaller alterability coefficients. Alterability coefficients of \eqn{0.0} define fixed (binding) problem 
-#' values while alterability coefficients greater than \eqn{0.0} define free (nonbinding) values. The default alterability 
-#' coefficients are \eqn{0.0} for temporal totals (argument `alter_temporal`) and \eqn{1.0} for period values (arguments 
-#' `alter_pos`, `alter_neg`, `alter_mix`). In the common case of aggregation table raking problems, the period values of the 
-#' marginal totals (time series with a coefficient of \eqn{-1} in the balancing constraints) are usually binding (specified 
-#' with `alter_neg = 0`) while the period values of the component series (time series with a coefficient of \eqn{1} in the 
-#' balancing constraints) are usually nonbinding (specified with `alter_pos > 0`, e.g., `alter_pos = 1`). *Almost binding* 
-#' problem values (e.g., marginal totals or temporal totals) can be obtained in practice by specifying very small (almost 
+#' Alterability coefficients are nonnegative numbers that change the relative cost of modifying an initial problem value.
+#' By changing the actual objective function to minimize, they allow the generation of a wide range of solutions. Since they
+#' appear in the denominator of the objective function (matrix \eqn{W}), the larger the alterability coefficient the less costly
+#' it is to modify a problem value (period value or temporal total) and, conversely, the smaller the alterability coefficient
+#' the more costly it becomes. This results in problem values with larger alterability coefficients proportionally changing more
+#' than the ones with smaller alterability coefficients. Alterability coefficients of \eqn{0.0} define fixed (binding) problem
+#' values while alterability coefficients greater than \eqn{0.0} define free (nonbinding) values. The default alterability
+#' coefficients are \eqn{0.0} for temporal totals (argument `alter_temporal`) and \eqn{1.0} for period values (arguments
+#' `alter_pos`, `alter_neg`, `alter_mix`). In the common case of aggregation table raking problems, the period values of the
+#' marginal totals (time series with a coefficient of \eqn{-1} in the balancing constraints) are usually binding (specified
+#' with `alter_neg = 0`) while the period values of the component series (time series with a coefficient of \eqn{1} in the
+#' balancing constraints) are usually nonbinding (specified with `alter_pos > 0`, e.g., `alter_pos = 1`). *Almost binding*
+#' problem values (e.g., marginal totals or temporal totals) can be obtained in practice by specifying very small (almost
 #' \eqn{0.0}) alterability coefficients relative to those of the other (nonbinding) problem values.
-#' 
-#' **Temporal total preservation** refers to the fact that temporal totals, when applicable, are usually kept “as close as 
-#' possible” to their initial value. *Pure preservation* is achieved by default with binding temporal totals while the change 
+#'
+#' **Temporal total preservation** refers to the fact that temporal totals, when applicable, are usually kept “as close as
+#' possible” to their initial value. *Pure preservation* is achieved by default with binding temporal totals while the change
 #' is minimized with nonbinding temporal totals (in accordance with the set of alterability coefficients).
-#' 
-#' 
+#'
+#'
 #' ## Validation and troubleshooting
-#' Successful balancing problems (problems with a valid solution) have `sol_status_val > 0` or, equivalently, 
-#' `n_unmet_con = 0` or `max_discr <= validation_tol` in the output `proc_grp_df` data frame. Troubleshooting 
+#' Successful balancing problems (problems with a valid solution) have `sol_status_val > 0` or, equivalently,
+#' `n_unmet_con = 0` or `max_discr <= validation_tol` in the output `proc_grp_df` data frame. Troubleshooting
 #' unsuccessful balancing problems is not necessarily straightforward. Following are some suggestions:
-#' 
-#' - Investigate the failed constraints (`unmet_flag = TRUE` or, equivalently, `discr_out > validation_tol` in the 
+#'
+#' - Investigate the failed constraints (`unmet_flag = TRUE` or, equivalently, `discr_out > validation_tol` in the
 #' output `prob_con_df` data frame) to make sure that they do not cause an empty solution space (infeasible problem).
-#' 
+#'
 #' - Change the OSQP solving sequence. E.g., try:
 #'   1. argument `full_sequence = TRUE`
 #'   2. argument `osqp_settings_df = alternate_osqp_sequence`
 #'   3. arguments `osqp_settings_df = alternate_osqp_sequence` and `full_sequence = TRUE`
-#'   
+#'
 #'   See `vignette("osqp-settings-sequence-dataframe")` for more details on this topic.
-#'   
-#' - Increase (review) the `validation_tol` value. Although this may sound like *cheating*, the default `validation_tol` 
-#' value (\eqn{1 \times 10^{-3}}) may actually be too small for balancing problems that involve very large values (e.g., 
-#' in billions) or, conversely, too large with very small problem values (e.g, \eqn{< 1.0}). Multiplying the average scale 
-#' of the problem data by the *machine tolerance* (`.Machine$double.eps`) gives an approximation of the average size of the 
-#' discrepancies that [tsbalancing()] should be able to handle (distinguish from \eqn{0}) and should probably constitute an 
-#' **absolute lower bound** for argument `validation_tol`. In practice, a reasonable `validation_tol` value would likely be 
+#'
+#' - Increase (review) the `validation_tol` value. Although this may sound like *cheating*, the default `validation_tol`
+#' value (\eqn{1 \times 10^{-3}}) may actually be too small for balancing problems that involve very large values (e.g.,
+#' in billions) or, conversely, too large with very small problem values (e.g, \eqn{< 1.0}). Multiplying the average scale
+#' of the problem data by the *machine tolerance* (`.Machine$double.eps`) gives an approximation of the average size of the
+#' discrepancies that [tsbalancing()] should be able to handle (distinguish from \eqn{0}) and should probably constitute an
+#' **absolute lower bound** for argument `validation_tol`. In practice, a reasonable `validation_tol` value would likely be
 #' \eqn{1 \times 10^3} to \eqn{1 \times 10^6} times larger than this *lower bound*.
-#'   
-#' - Address constraints redundancy. Multi-dimensional aggregation table raking problems are over-specified (involve 
-#' redundant constraints) when all totals of all dimensions of the *data cube* are binding (fixed) and a constraint is 
-#' defined for all of them. Redundancy also occurs for the implicit temporal aggregation constraints in single- or 
-#' multi-dimensional aggregation table raking problems with binding (fixed) temporal totals. Over-specification is generally 
-#' not an issue for [tsbalancing()] if the input data are not contradictory with regards to the redundant constraints, i.e., 
-#' if there are no inconsistencies (discrepancies) associated to the redundant constraints in the input data or if they are 
-#' *negligible* (reasonably small relative to the scale of the problem data). Otherwise, this may lead to unsuccessful 
+#'
+#' - Address constraints redundancy. Multi-dimensional aggregation table raking problems are over-specified (involve
+#' redundant constraints) when all totals of all dimensions of the *data cube* are binding (fixed) and a constraint is
+#' defined for all of them. Redundancy also occurs for the implicit temporal aggregation constraints in single- or
+#' multi-dimensional aggregation table raking problems with binding (fixed) temporal totals. Over-specification is generally
+#' not an issue for [tsbalancing()] if the input data are not contradictory with regards to the redundant constraints, i.e.,
+#' if there are no inconsistencies (discrepancies) associated to the redundant constraints in the input data or if they are
+#' *negligible* (reasonably small relative to the scale of the problem data). Otherwise, this may lead to unsuccessful
 #' balancing problems with [tsbalancing()]. Possible solutions would then include:
 #'   1. Resolve (or reduce) the discrepancies associated to the redundant constraints in the input data.
-#'   2. Select one marginal total in every dimension, but one, of the data cube and remove the corresponding balancing 
+#'   2. Select one marginal total in every dimension, but one, of the data cube and remove the corresponding balancing
 #'   constraints from the problem. *This cannot be done for the implicit temporal aggregation constraints*.
-#'   3. Select one marginal total in every dimension, but one, of the data cube and make them nonbinding (alterability 
-#'   coefficient of, say, \eqn{1.0}). 
+#'   3. Select one marginal total in every dimension, but one, of the data cube and make them nonbinding (alterability
+#'   coefficient of, say, \eqn{1.0}).
 #'   4. Do the same as (3) for the temporal totals of one of the inner-cube component series (make them nonbinding).
-#'   5. Make all marginal totals of every dimension, but one, of the data cube *amlost binding*, i.e., specify very small 
-#'   alterability coefficients (say \eqn{1 \times 10^{-6}}) compared to those of the inner-cube component series. 
-#'   6. Do the same as (5) for the temporal totals of all inner-cube component series (very small alterability 
+#'   5. Make all marginal totals of every dimension, but one, of the data cube *amlost binding*, i.e., specify very small
+#'   alterability coefficients (say \eqn{1 \times 10^{-6}}) compared to those of the inner-cube component series.
+#'   6. Do the same as (5) for the temporal totals of all inner-cube component series (very small alterability
 #'   coefficients, e.g., with argument `alter_temporal`).
-#'   7. Use [tsraking()] (if applicable), which handles these inconsistencies by using the Moore-Penrose inverse  
+#'   7. Use [tsraking()] (if applicable), which handles these inconsistencies by using the Moore-Penrose inverse
 #'   (uniform distribution among all binding totals).
-#'        
-#'   Solutions (2) to (7) above should only be considered if the discrepancies associated to the redundant constraints 
-#'   in the input data are *reasonably small* as they would be distributed among the omitted or nonbinding totals with 
+#'
+#'   Solutions (2) to (7) above should only be considered if the discrepancies associated to the redundant constraints
+#'   in the input data are *reasonably small* as they would be distributed among the omitted or nonbinding totals with
 #'   [tsbalancing()] and all binding totals with [tsraking()]. Otherwise, one should first investigate solution (1) above.
-#' 
+#'
 #' - Relax the bounds of the problem constraints, e.g.:
 #'   - argument `tolV` for the balancing constraints;
 #'   - arguments `tolV_temporal` and `tolP_temporal` for the implicit temporal aggregation constraints;
 #'   - arguments `lower_bound` and `upper_bound`.
-#' 
-#' 
+#'
+#'
 #' # Processing groups
-#' The set of periods of a given reconciliation (raking or balancing) problem is called a *processing group* 
+#' The set of periods of a given reconciliation (raking or balancing) problem is called a *processing group*
 #' and either corresponds to:
-#' - a **single period** with period-by-period processing or, when preserving temporal totals, for the individual 
+#' - a **single period** with period-by-period processing or, when preserving temporal totals, for the individual
 #' periods of an incomplete temporal group (e.g., an incomplete year)
-#' - or the **set of periods of a complete temporal group** (e.g., a complete year) when preserving temporal 
-#' totals. 
-#' 
-#' The total number of processing groups (total number of reconciliation problems) depends on the set of 
-#' periods in the input time series object (argument `in_ts`) and on the value of arguments 
-#' `temporal_grp_periodicity` and `temporal_grp_start`. 
-#' 
-#' Common scenarios include `temporal_grp_periodicity = 1` (default) for period-by period processing without 
-#' temporal total preservation and `temporal_grp_periodicity = frequency(in_ts)` for the preservation of annual 
-#' totals (calendar years by default). Argument `temporal_grp_start` allows the specification of other types of 
-#' (_non-calendar_) years. E.g., fiscal years starting on April correspond to `temporal_grp_start = 4` with monthly 
-#' data and `temporal_grp_start = 2` with quarterly data. Preserving quarterly totals with monthly data would 
-#' correspond to \ifelse{latex}{\code{temporal_grp _periodicity = 3}}{\code{temporal_grp_periodicity = 3}}. 
-#' 
+#' - or the **set of periods of a complete temporal group** (e.g., a complete year) when preserving temporal
+#' totals.
+#'
+#' The total number of processing groups (total number of reconciliation problems) depends on the set of
+#' periods in the input time series object (argument `in_ts`) and on the value of arguments
+#' `temporal_grp_periodicity` and `temporal_grp_start`.
+#'
+#' Common scenarios include `temporal_grp_periodicity = 1` (default) for period-by period processing without
+#' temporal total preservation and `temporal_grp_periodicity = frequency(in_ts)` for the preservation of annual
+#' totals (calendar years by default). Argument `temporal_grp_start` allows the specification of other types of
+#' (_non-calendar_) years. E.g., fiscal years starting on April correspond to `temporal_grp_start = 4` with monthly
+#' data and `temporal_grp_start = 2` with quarterly data. Preserving quarterly totals with monthly data would
+#' correspond to \ifelse{latex}{\code{temporal_grp _periodicity = 3}}{\code{temporal_grp_periodicity = 3}}.
+#'
 #' By default, temporal groups covering more than a year (i.e., corresponding to \ifelse{latex}{\code{
-#' temporal_grp _periodicity > frequency(in_ts)}}{\code{temporal_grp_periodicity > frequency(in_ts)}} start on a 
+#' temporal_grp _periodicity > frequency(in_ts)}}{\code{temporal_grp_periodicity > frequency(in_ts)}} start on a
 #' year that is a multiple of \ifelse{latex}{\code{ceiling(temporal_grp _periodicity / frequency(in_ts))}}{\code{
 #' ceiling(temporal_grp_periodicity / frequency(in_ts))}}. E.g., biennial groups corresponding to \ifelse{latex}{
 #' \code{temporal_grp_per iodicity = 2 * frequency(in_ts)}}{\code{temporal_grp_periodicity = 2 * frequency(in_ts)}}
-#' start on an _even year_ by default. This behaviour can be changed with argument `temporal_grp_start`. E.g., the 
-#' preservation of biennial totals starting on an _odd year_ instead of an _even year_ (default) corresponds to 
+#' start on an _even year_ by default. This behaviour can be changed with argument `temporal_grp_start`. E.g., the
+#' preservation of biennial totals starting on an _odd year_ instead of an _even year_ (default) corresponds to
 #' `temporal_grp_start = frequency(in_ts) + 1` (along with `temporal_grp_periodicity = 2 * frequency(in_ts)`).
-#' 
+#'
 #' See the [gs.build_proc_grps()] **Examples** for common processing group scenarios.
-#' 
-#' 
+#'
+#'
 #' # Comparing [tsraking()] and [tsbalancing()]
-#' - [tsraking()] is limited to one- and two-dimensional aggregation table raking problems (with temporal total 
-#' preservation if required) while [tsbalancing()] handles more general balancing problems (e.g., higher dimensional 
-#' raking problems, nonnegative solutions, general linear equality and inequality constraints as opposed to aggregation 
+#' - [tsraking()] is limited to one- and two-dimensional aggregation table raking problems (with temporal total
+#' preservation if required) while [tsbalancing()] handles more general balancing problems (e.g., higher dimensional
+#' raking problems, nonnegative solutions, general linear equality and inequality constraints as opposed to aggregation
 #' rules only, etc.).
-#' - [tsraking()] returns the generalized least squared solution of the Dagum and Cholette regression-based raking 
-#' model (Dagum and Cholette 2006) while [tsbalancing()] solves the corresponding quadratic minimization problem using 
-#' a numerical solver. In most cases, *convergence to the minimum* is achieved and the [tsbalancing()] solution matches 
-#' the (exact) [tsraking()] least square solution. It may not be the case, however, if convergence could not be achieved 
-#' after a reasonable number of iterations. Having said that, only in very rare occasions will the [tsbalancing()] 
+#' - [tsraking()] returns the generalized least squared solution of the Dagum and Cholette regression-based raking
+#' model (Dagum and Cholette 2006) while [tsbalancing()] solves the corresponding quadratic minimization problem using
+#' a numerical solver. In most cases, *convergence to the minimum* is achieved and the [tsbalancing()] solution matches
+#' the (exact) [tsraking()] least square solution. It may not be the case, however, if convergence could not be achieved
+#' after a reasonable number of iterations. Having said that, only in very rare occasions will the [tsbalancing()]
 #' solution *significantly* differ from the [tsraking()] solution.
-#' - [tsbalancing()] is usually faster than [tsraking()], especially for large raking problems, but is generally more 
-#' sensitive to the presence of (small) inconsistencies in the input data associated to the redundant constraints of 
-#' fully specified (over-specified) raking problems. [tsraking()] handles these inconsistencies by using the 
-#' Moore-Penrose inverse (uniform distribution among all binding totals). 
-#' - [tsbalancing()] accommodates the specification of sparse problems in their reduced form. This is not true in the 
-#' case of [tsraking()] where aggregation rules must always be fully specified since a *complete data cube* without 
-#' missing data is expected as input (every single *inner-cube* component series must contribute to all dimensions of 
+#' - [tsbalancing()] is usually faster than [tsraking()], especially for large raking problems, but is generally more
+#' sensitive to the presence of (small) inconsistencies in the input data associated to the redundant constraints of
+#' fully specified (over-specified) raking problems. [tsraking()] handles these inconsistencies by using the
+#' Moore-Penrose inverse (uniform distribution among all binding totals).
+#' - [tsbalancing()] accommodates the specification of sparse problems in their reduced form. This is not true in the
+#' case of [tsraking()] where aggregation rules must always be fully specified since a *complete data cube* without
+#' missing data is expected as input (every single *inner-cube* component series must contribute to all dimensions of
 #' the cube, i.e., to every single *outer-cube* marginal total series).
-#' - Both tools handle negative values in the input data differently by default. While the solutions of raking problems 
-#' obtained from [tsbalancing()] and [tsraking()] are identical when all input data points are positive, they will 
+#' - Both tools handle negative values in the input data differently by default. While the solutions of raking problems
+#' obtained from [tsbalancing()] and [tsraking()] are identical when all input data points are positive, they will
 #' differ if some data points are negative (unless argument `Vmat_option = 2` is specified with [tsraking()]).
-#' - While both [tsbalancing()] and [tsraking()] allow the preservation of temporal totals, time management is not 
-#' incorporated in [tsraking()]. For example, the construction of the processing groups (sets of periods of each raking 
-#' problem) is left to the user with [tsraking()] and separate calls must be submitted for each processing group (each 
+#' - While both [tsbalancing()] and [tsraking()] allow the preservation of temporal totals, time management is not
+#' incorporated in [tsraking()]. For example, the construction of the processing groups (sets of periods of each raking
+#' problem) is left to the user with [tsraking()] and separate calls must be submitted for each processing group (each
 #' raking problem). That's where helper function [tsraking_driver()] comes in handy with [tsraking()].
-#' - [tsbalancing()] returns the same set of series as the input time series object while [tsraking()] returns the set 
-#' of series involved in the raking problem plus those specified with argument `id` (which could correspond to a subset 
+#' - [tsbalancing()] returns the same set of series as the input time series object while [tsraking()] returns the set
+#' of series involved in the raking problem plus those specified with argument `id` (which could correspond to a subset
 #' of the input series).
 #'
 #'
 #' @returns
 #' The function returns is a list of seven objects:
-#' 
-#' - `out_ts`: modified version of the input time series object (class "ts" or "mts"; see argument `in_ts`) with the resulting 
-#' reconciled time series values (primary function output). It can be explicitly coerced to another type of object with the 
+#'
+#' - `out_ts`: modified version of the input time series object (class "ts" or "mts"; see argument `in_ts`) with the resulting
+#' reconciled time series values (primary function output). It can be explicitly coerced to another type of object with the
 #' appropriate `as*()` function (e.g., `tsibble::as_tsibble()` would coerce it to a tsibble).
-#' 
-#' - `proc_grp_df`: processing group summary data frame, useful to identify problems that have succeeded or failed. 
+#'
+#' - `proc_grp_df`: processing group summary data frame, useful to identify problems that have succeeded or failed.
 #' It contains one observation (row) for each balancing problem with the following columns:
 #'   - `proc_grp` (num): processing group id.
 #'   - `proc_grp_type` (chr): processing group type. Possible values are:
@@ -510,29 +510,29 @@
 #'     - `"initial"` (initial solution, i.e., input data values);
 #'     - `"osqp"` (OSQP solution).
 #'   - `osqp_attempts` (num): number of attempts made with OSQP (depth achieved in the solving sequence).
-#'   - `osqp_seqno` (num): step # of the solving sequence corresponding to the returned solution. `NA` when 
+#'   - `osqp_seqno` (num): step # of the solving sequence corresponding to the returned solution. `NA` when
 #'   `sol_type = "initial"`.
 #'   - `osqp_status` (chr): OSQP status description string (`osqp_sol_info_df$status`). `NA` when `sol_type = "initial"`.
-#'   - `osqp_polished` (logi): `TRUE` if the returned OSQP solution is polished (\ifelse{latex}{\code{osqp_sol_info_df 
+#'   - `osqp_polished` (logi): `TRUE` if the returned OSQP solution is polished (\ifelse{latex}{\code{osqp_sol_info_df
 #'   $status_polish = 1}}{\code{osqp_sol_info_df$status_polish = 1}}), `FALSE` otherwise. `NA` when `sol_type = "initial"`.
 #'   - `total_solve_time` (num): total time, in seconds, of the solving sequence.
-#'   
-#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Successful balancing problems 
-#'   (problems with a valid solution) correspond to rows with `sol_status_val > 0` or, equivalently, to `n_unmet_con = 0` 
-#'   or to `max_discr <= validation_tol`. The *initial solution* (`sol_type = "initial"`) is returned only if **a)** 
-#'   there are no initial constraint discrepancies, **b)** the problem is fixed (all values are binding) or **c)** it beats 
+#'
+#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Successful balancing problems
+#'   (problems with a valid solution) correspond to rows with `sol_status_val > 0` or, equivalently, to `n_unmet_con = 0`
+#'   or to `max_discr <= validation_tol`. The *initial solution* (`sol_type = "initial"`) is returned only if **a)**
+#'   there are no initial constraint discrepancies, **b)** the problem is fixed (all values are binding) or **c)** it beats
 #'   the OSQP solution (smaller total constraint discrepancies). The OSQP solving sequence is described in \ifelse{latex}{
 #'   \code{vignette("osqp-settings -sequence-dataframe")}}{\code{vignette("osqp-settings-sequence-dataframe")}}.
-#'     
-#' - `periods_df`: time periods data frame, useful to match periods to processing groups. It contains one observation 
+#'
+#' - `periods_df`: time periods data frame, useful to match periods to processing groups. It contains one observation
 #' (row) for each period of the input time series object (argument `in_ts`) with the following columns:
 #'   - `proc_grp` (num): processing group id.
 #'   - `t` (num): time id (`1:nrow(in_ts)`).
 #'   - `time_val` (num): time value (`stats::time(in_ts)`). It conceptually corresponds to \eqn{year + (period - 1) / frequency}.
-#'   
+#'
 #'   Columns `t` and `time_val` both constitute a *unique key* (distinct rows) for the data frame.
-#' 
-#' - `prob_val_df`: problem values data frame, useful to analyze change diagnostics, i.e., initial vs final (reconciled) 
+#'
+#' - `prob_val_df`: problem values data frame, useful to analyze change diagnostics, i.e., initial vs final (reconciled)
 #' values. It contains one observation (row) for each value involved in each balancing problem, with the following columns:
 #'   - `proc_grp` (num): processing group id.
 #'   - `val_type` (chr): problem value type. Possible values are:
@@ -540,49 +540,49 @@
 #'     - `"temporal total"`.
 #'   - `name` (chr): time series (variable) name.
 #'   - `t` (num): time id (`1:nrow(in_ts)`); id of the first period of the temporal group for a *temporal total*.
-#'   - `time_val` (num): time value (`stats::time(in_ts)`); value of the first period of the temporal group for a 
+#'   - `time_val` (num): time value (`stats::time(in_ts)`); value of the first period of the temporal group for a
 #'   *temporal total*. It conceptually corresponds to \eqn{year + (period - 1) / frequency}.
 #'   - `lower_bd`, `upper_bd` (num): period value bounds; always `-Inf` and `Inf` for a *temporal total*.
 #'   - `alter` (num): alterability coefficient.
 #'   - `value_in`, `value_out` (num): initial and final (reconciled) values.
 #'   - `dif` (num): `value_out - value_in`.
 #'   - `rdif` (num): `dif / value_in`; `NA` if `value_in = 0`.
-#'   
-#'   Columns `val_type + name + t` and `val_type + name + time_val` both constitute a *unique key* (distinct rows) for the 
-#'   data frame. Binding (fixed) problem values correspond to rows with `alter = 0` or `value_in = 0`. Conversely, nonbinding 
+#'
+#'   Columns `val_type + name + t` and `val_type + name + time_val` both constitute a *unique key* (distinct rows) for the
+#'   data frame. Binding (fixed) problem values correspond to rows with `alter = 0` or `value_in = 0`. Conversely, nonbinding
 #'   (free) problem values correspond to rows with `alter != 0` and `value_in != 0`.
-#'   
-#' - `prob_con_df`: problem constraints data frame, useful for troubleshooting problems that failed (identify unmet 
-#' constraints). It contains one observation (row) for each constraint involved in each balancing problem, with the following 
+#'
+#' - `prob_con_df`: problem constraints data frame, useful for troubleshooting problems that failed (identify unmet
+#' constraints). It contains one observation (row) for each constraint involved in each balancing problem, with the following
 #' columns:
 #'   - `proc_grp` (num): processing group id.
 #'   - `con_type` (chr): problem constraint type. Possible values are:
 #'     - `"balancing constraint"`;
 #'     - `"temporal aggregation constraint"`;
 #'     - `"period value bounds"`.
-#'     
-#'     While *balancing constraints* are specicied by the user, the other two types of constraints (*temporal aggregation 
+#'
+#'     While *balancing constraints* are specicied by the user, the other two types of constraints (*temporal aggregation
 #'     constraints* and *period value bounds*) are automatically added to the problem by the function (when applicable).
 #'   - `name` (chr): constraint label or time series (variable) name.
 #'   - `t` (num): time id (`1:nrow(in_ts)`); id of the first period of the temporal group for a *temporal aggregation constraint*.
-#'   - `time_val` (num): time value (`stats::time(in_ts)`); value of the first period of the temporal group for a *temporal 
+#'   - `time_val` (num): time value (`stats::time(in_ts)`); value of the first period of the temporal group for a *temporal
 #'   aggregation constraint*. It conceptually corresponds to \eqn{year + (period - 1) / frequency}.
-#'   - `l`, `u`, `Ax_in`, `Ax_out` (num): initial and final constraint elements \eqn{\left( \mathbf{l} \le A \mathbf{x} \le 
+#'   - `l`, `u`, `Ax_in`, `Ax_out` (num): initial and final constraint elements \eqn{\left( \mathbf{l} \le A \mathbf{x} \le
 #'   \mathbf{u} \right)}{(l <= Ax <= u)}.
-#'   - `discr_in`, `discr_out` (num): initial and final constraint discrepancies \eqn{\left( \max \left( 0, \mathbf{l} - A 
+#'   - `discr_in`, `discr_out` (num): initial and final constraint discrepancies \eqn{\left( \max \left( 0, \mathbf{l} - A
 #'   \mathbf{x}, A \mathbf{x} - \mathbf{u} \right) \right)}{(max(0, l - Ax, Ax - u))}.
 #'   - `validation_tol` (num): specified tolerance for validation purposes (argument `validation_tol`).
 #'   - `unmet_flag` (logi): `TRUE` if the constraint is not met (`discr_out > validation_tol`), `FALSE` otherwise.
-#'   
-#'   Columns `con_type + name + t` and `con_type + name + time_val` both constitute a *unique key* (distinct rows) for the 
-#'   data frame. Constraint bounds \eqn{\mathbf{l = u}}{l = u} for `EQ` constraints, \eqn{\mathbf{l} = -\infty}{l = -Inf} for 
-#'   `LE` constraints, \eqn{\mathbf{u} = \infty}{u = Inf} for `GE` constraints, and include the tolerances, when applicable, 
+#'
+#'   Columns `con_type + name + t` and `con_type + name + time_val` both constitute a *unique key* (distinct rows) for the
+#'   data frame. Constraint bounds \eqn{\mathbf{l = u}}{l = u} for `EQ` constraints, \eqn{\mathbf{l} = -\infty}{l = -Inf} for
+#'   `LE` constraints, \eqn{\mathbf{u} = \infty}{u = Inf} for `GE` constraints, and include the tolerances, when applicable,
 #'   specified with arguments `tolV`, `tolV_temporal` and `tolP_temporal`.
-#' 
-#' - `osqp_settings_df`: OSQP settings data frame. It contains one observation (row) for each problem (processing group) 
+#'
+#' - `osqp_settings_df`: OSQP settings data frame. It contains one observation (row) for each problem (processing group)
 #' solved with OSQP (`proc_grp_df$sol_type = "osqp"`), with the following columns:
 #'   - `proc_grp` (num): processing group id.
-#'   - one column corresponding to each element of the list returned by the `osqp::GetParams()` method applied to a 
+#'   - one column corresponding to each element of the list returned by the `osqp::GetParams()` method applied to a
 #'   *OSQP solver object* (class "osqp_model" object as returned by [osqp::osqp()]), e.g.:
 #'     - Maximum iterations (`max_iter`);
 #'     - Primal and dual infeasibility tolerances (`eps_prim_inf` and `eps_dual_inf`);
@@ -590,21 +590,21 @@
 #'     - Number of scaling iterations (`scaling`);
 #'     - etc.
 #'   - extra settings specific to [tsbalancing()]:
-#'     - `prior_scaling` (logi): `TRUE` if the problem data were scaled (using the average of the free (nonbinding) problem 
+#'     - `prior_scaling` (logi): `TRUE` if the problem data were scaled (using the average of the free (nonbinding) problem
 #'     values as the scaling factor) prior to solving with OSQP, `FALSE` otherwise.
-#'     - `require_polished` (logi): `TRUE` if a polished solution from OSQP (\ifelse{latex}{\code{osqp_sol_info_df 
-#'     $status_polish = 1}}{\code{osqp_sol_info_df$status_polish = 1}}) was required for this step in order to end the solving 
-#'     sequence, `FALSE` otherwise. See `vignette("osqp-settings-sequence-dataframe")` for more details on the solving sequence 
+#'     - `require_polished` (logi): `TRUE` if a polished solution from OSQP (\ifelse{latex}{\code{osqp_sol_info_df
+#'     $status_polish = 1}}{\code{osqp_sol_info_df$status_polish = 1}}) was required for this step in order to end the solving
+#'     sequence, `FALSE` otherwise. See `vignette("osqp-settings-sequence-dataframe")` for more details on the solving sequence
 #'     used by [tsbalancing()].
-#'     
-#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Visit 
-#'   <https://osqp.org/docs/interfaces/solver_settings.html> for all available OSQP settings. Problems (processing groups) for 
+#'
+#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Visit
+#'   <https://osqp.org/docs/interfaces/solver_settings.html> for all available OSQP settings. Problems (processing groups) for
 #'   which the initial solution was returned (`proc_grp_df$sol_type = "initial"`) are not included in this data frame.
-#' 
-#' - `osqp_sol_info_df`: OSQP solution information data frame. It contains one observation (row) for each problem 
+#'
+#' - `osqp_sol_info_df`: OSQP solution information data frame. It contains one observation (row) for each problem
 #' (processing group) solved with OSQP (`proc_grp_df$sol_type = "osqp"`), with the following columns:
 #'   - `proc_grp` (num): processing group id.
-#'   - one column corresponding to each element of the `info` list of a *OSQP solver object* (class "osqp_model" object 
+#'   - one column corresponding to each element of the `info` list of a *OSQP solver object* (class "osqp_model" object
 #'   as returned by [osqp::osqp()]) after having been solved with the `osqp::Solve()` method, e.g.:
 #'     - Solution status (`status` and `status_val`);
 #'     - Polishing status (`status_polish`);
@@ -614,49 +614,49 @@
 #'     - Solve time (`solve_time`);
 #'     - etc.
 #'   - extra information specific to [tsbalancing()]:
-#'     - `prior_scaling_factor` (num): value of the scaling factor when \ifelse{latex}{\code{osqp_settings_df $prior_scaling 
+#'     - `prior_scaling_factor` (num): value of the scaling factor when \ifelse{latex}{\code{osqp_settings_df $prior_scaling
 #'     = TRUE}}{\code{osqp_settings_df$prior_scaling = TRUE}} (`prior_scaling_factor = 1.0` otherwise).
-#'     - `obj_val_ori_prob` (num): original balancing problem's objective function value, which is the OSQP objective function 
-#'     value (`obj_val`) on the original scale (when \code{osqp_settings_df$prior_scaling = TRUE}) plus the constant term of 
-#'     the original balancing problem's objective function, i.e., \ifelse{latex}{\code{obj_val_ori_prob = obj_val * 
-#'     prior _scaling_factor + <constant term>}}{\code{obj_val_ori_prob = obj_val * prior_scaling_factor + <constant term>}}, 
-#'     where `<constant term>` corresponds to 
-#'     \eqn{\mathbf{y}^{\mathrm{T}} W \mathbf{y}}{y' W y}. See section **Details** for the definition of vector 
-#'     \eqn{\mathbf{y}}{y}, matrix \eqn{W} and, more generally speaking, the complete expression of the balancing problem's 
+#'     - `obj_val_ori_prob` (num): original balancing problem's objective function value, which is the OSQP objective function
+#'     value (`obj_val`) on the original scale (when \code{osqp_settings_df$prior_scaling = TRUE}) plus the constant term of
+#'     the original balancing problem's objective function, i.e., \ifelse{latex}{\code{obj_val_ori_prob = obj_val *
+#'     prior _scaling_factor + <constant term>}}{\code{obj_val_ori_prob = obj_val * prior_scaling_factor + <constant term>}},
+#'     where `<constant term>` corresponds to
+#'     \eqn{\mathbf{y}^{\mathrm{T}} W \mathbf{y}}{y' W y}. See section **Details** for the definition of vector
+#'     \eqn{\mathbf{y}}{y}, matrix \eqn{W} and, more generally speaking, the complete expression of the balancing problem's
 #'     objective function.
-#' 
-#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Visit <https://osqp.org> for more information on 
-#'   OSQP. Problems (processing groups) for which the initial solution was returned (`proc_grp_df$sol_type = "initial"`) are not 
+#'
+#'   Column `proc_grp` constitutes a *unique key* (distinct rows) for the data frame. Visit <https://osqp.org> for more information on
+#'   OSQP. Problems (processing groups) for which the initial solution was returned (`proc_grp_df$sol_type = "initial"`) are not
 #'   included in this data frame.
 #'
-#' Note that the "data.frame" objects returned by the function can be explicitly coerced to other types of objects with 
+#' Note that the "data.frame" objects returned by the function can be explicitly coerced to other types of objects with
 #' the appropriate `as*()` function (e.g., `tibble::as_tibble()` would coerce any of them to a tibble).
 #'
 #'
 #' @references Dagum, E. B. and P. Cholette (2006). **Benchmarking, Temporal Distribution and Reconciliation Methods
 #' of Time Series**. Springer-Verlag, New York, Lecture Notes in Statistics, Vol. 186.
 #'
-#' @references Ferland, M., S. Fortier and J. Bérubé (2016). "A Mathematical Optimization Approach to Balancing Time Series: 
-#' Statistics Canada’s GSeriesTSBalancing". In **JSM Proceedings, Business and Economic Statistics Section**. Alexandria, 
+#' @references Ferland, M., S. Fortier and J. Bérubé (2016). "A Mathematical Optimization Approach to Balancing Time Series:
+#' Statistics Canada’s GSeriesTSBalancing". In **JSM Proceedings, Business and Economic Statistics Section**. Alexandria,
 #' VA: American Statistical Association. 2292-2306.
-#' 
-#' @references Ferland, M. (2018). "Time Series Balancing Quadratic Problem — Hessian matrix and vector of linear objective 
+#'
+#' @references Ferland, M. (2018). "Time Series Balancing Quadratic Problem — Hessian matrix and vector of linear objective
 #' function coefficients". **Internal document**. Statistics Canada, Ottawa, Canada.
 #'
 #' @references Quenneville, B. and S. Fortier (2012). "Restoring Accounting Constraints in Time Series – Methods and
 #' Software for a Statistical Agency". **Economic Time Series: Modeling and Seasonality**. Chapman & Hall, New York.
-#' 
-#' @references SAS Institute Inc. (2015). "The LP Procedure Sparse Data Input Format". **SAS/OR\eqn{^\circledR}{®} 14.1 
-#' User's Guide: Mathematical Programming Legacy Procedures**. 
+#'
+#' @references SAS Institute Inc. (2015). "The LP Procedure Sparse Data Input Format". **SAS/OR\eqn{^\circledR}{®} 14.1
+#' User's Guide: Mathematical Programming Legacy Procedures**.
 #' <https://support.sas.com/documentation/cdl/en/ormplpug/68158/HTML/default/viewer.htm#ormplpug_lp_details03.htm>
-#' 
+#'
 #' @references Statistics Canada (2016). "The ***GSeriesTSBalancing*** Macro". **G-Series 2.0 User Guide**.
 #' Statistics Canada, Ottawa, Canada.
 #'
 #' @references Statistics Canada (2018). **Theory and Application of Reconciliation (Course code 0437)**.
 #' Statistics Canada, Ottawa, Canada.
 #'
-#' @references Stellato, B., G. Banjac, P. Goulart et al. (2020). "OSQP: an operator splitting solver for quadratic programs". 
+#' @references Stellato, B., G. Banjac, P. Goulart et al. (2020). "OSQP: an operator splitting solver for quadratic programs".
 #' **Math. Prog. Comp. 12**, 637–672 (2020). <https://doi.org/10.1007/s12532-020-00179-2>
 #'
 #'
@@ -682,17 +682,12 @@ tsbalancing <- function(in_ts,
                         tolV = 0,
                         tolV_temporal = 0,
                         tolP_temporal = NA,
-
                         # New in G-Series 3.0
                         validation_tol = 0.001,
                         trunc_to_zero_tol = validation_tol,
                         full_sequence = FALSE,
                         validation_only = FALSE,
                         quiet = FALSE) {
-
-
-
-
   ### Internal functions ###
 
   # Display the Problem Specs data frame info
@@ -700,7 +695,7 @@ tsbalancing <- function(in_ts,
   # Main (parent) function objects used in this function:
   #   - pb         : balancing problem core elements (building blocks), namely (elements of the list):
   #     - labels_df: problem specs labels
-  #     - coefs_df : problem specs coefficients 
+  #     - coefs_df : problem specs coefficients
   #     - ser_names: vector of all series names involved in the balancing problem
   #     - lb       : lower bounds info (list object)
   #     - ub       : upper bounds info (list object)
@@ -711,10 +706,9 @@ tsbalancing <- function(in_ts,
   #     - mix_ser  : vector of series names with both positive and negative constraint coefficients (across all constraints)
   #   - n_ser      : `length(pb$ser_names)`
   #   - n_con      : `length(pb$labels_df$row.lc[pb$labels_df$con.flag])`
-  #   - arguments `alter_pos`, `alter_neg`, `alter_mix`, `alter_temporal`, `lower_bound`, `upper_bound`, 
+  #   - arguments `alter_pos`, `alter_neg`, `alter_mix`, `alter_temporal`, `lower_bound`, `upper_bound`,
   #     `validation_only` and `temporal_grp_periodicity`
   print_specs <- function() {
-
     # Function to build the balancing constraint string for display
     build_con_str <- function(type_val, row_val, col_vec, coef_vec) {
       rhs_logic <- (col_vec == "_rhs_")
@@ -757,23 +751,26 @@ tsbalancing <- function(in_ts,
     message("\n\n  ", header, "\n  ", paste0(rep.int("-", nchar(header)), collapse = ""))
     for (ii in seq.int(n_con)) {
       logi_vec <- pb$coefs_df$row.lc == con_labels_df$row.lc[ii]
-      message("\n", build_con_str(type_val = con_labels_df$type.lc[ii],
-                                  row_val = con_labels_df$row[ii],
-                                  col_vec = pb$coefs_df$col[logi_vec],
-                                  coef_vec = pb$coefs_df$coef[logi_vec]))
+      message("\n", build_con_str(
+        type_val = con_labels_df$type.lc[ii],
+        row_val = con_labels_df$row[ii],
+        col_vec = pb$coefs_df$col[logi_vec],
+        coef_vec = pb$coefs_df$coef[logi_vec]
+      ))
     }
 
-    
-    # Function to pad the values of a character data frame column (character vector) to the right 
+
+    # Function to pad the values of a character data frame column (character vector) to the right
     # so that it is displayed as a left-aligned character column
     pad_right <- function(x) {
       len <- max(nchar(x))
       # `sapply()` is safe: it always returns a character vector (`x` is of length minimum 1)
-      paste0(x, sapply(len - nchar(x), 
-                       function(x) paste0(rep(" ", x), collapse = "")))
-      
+      paste0(x, sapply(
+        len - nchar(x),
+        function(x) paste0(rep(" ", x), collapse = "")
+      ))
     }
-    
+
     # Initialize the series info data frame (lower/upper bounds and alter/alterTmp coef values and source)
     series_info_df <- data.frame(
       name = pb$ser_names,
@@ -848,14 +845,16 @@ tsbalancing <- function(in_ts,
         }
       }
     }
-    
+
     # Keep relevant columns and assign the (duplicate/empty) column names for display
     series_info_df <- data.frame(series_info_df[col_id_vec])
-    cols_names <- c("name",
-                    "lowerBd", "", "",
-                    "upperBd", "", "",
-                    "alter", "", "", 
-                    "alterTmp", "", "")
+    cols_names <- c(
+      "name",
+      "lowerBd", "", "",
+      "upperBd", "", "",
+      "alter", "", "",
+      "alterTmp", "", ""
+    )
     names(series_info_df) <- cols_names[col_id_vec]
 
     # Display the time series info
@@ -896,10 +895,8 @@ tsbalancing <- function(in_ts,
   #   - prob_val_df: balancing problem values data frame
   #   - prob_con_df: balancing problem constraints data frame
   print_results <- function() {
-
-    
     # Problem values data frame
-    
+
     header <- "Problem Values"
     lines <- paste0(rep.int("-", nchar(header)), collapse = "")
     message("\n  ", lines, "\n  ", header, "\n  ", lines, "\n")
@@ -907,7 +904,8 @@ tsbalancing <- function(in_ts,
     if (sum(logi_vec) == 0) {
       df <- prob_val_df[, -c(1, 2)]
       message(paste0("  ", utils::capture.output(print.data.frame(df, row.names = FALSE, big_mark = ",")),
-                     collapse = "\n"), "\n")
+        collapse = "\n"
+      ), "\n")
     } else {
       header <- "Period Values"
       lines <- paste0(rep.int("-", nchar(header)), collapse = "")
@@ -921,9 +919,9 @@ tsbalancing <- function(in_ts,
       message(paste0("  ", utils::capture.output(print.data.frame(df, row.names = FALSE)), collapse = "\n"), "\n")
     }
 
-    
+
     # Problem constraints data frame
-    
+
     header <- "Problem Constraints (l <= Ax <= u)"
     lines <- paste0(rep.int("-", nchar(header)), collapse = "")
     message("\n  ", lines, "\n  ", header, "\n  ", lines, "\n")
@@ -931,7 +929,8 @@ tsbalancing <- function(in_ts,
     if (length(unique(prob_con_df$con_type)) == 1) {
       df <- prob_con_df[, -c(1, 2)]
       message(paste0("  ", utils::capture.output(print.data.frame(df, row.names = FALSE)),
-                     collapse = "\n"), "\n")
+        collapse = "\n"
+      ), "\n")
     } else {
       header <- "Balancing Constraints"
       lines <- paste0(rep.int("-", nchar(header)), collapse = "")
@@ -945,7 +944,8 @@ tsbalancing <- function(in_ts,
         message("  ", header, "\n  ", lines)
         df <- prob_con_df[logi_vec, -c(1, 2)]
         message(paste0("  ", utils::capture.output(print.data.frame(df, row.names = FALSE)),
-                       collapse = "\n"), "\n")
+          collapse = "\n"
+        ), "\n")
       }
       logi_vec <- (prob_con_df$con_type == "temporal aggregation constraint")
       if (sum(logi_vec) > 0) {
@@ -954,7 +954,8 @@ tsbalancing <- function(in_ts,
         message("  ", header, "\n  ", lines)
         df <- prob_con_df[logi_vec, -c(1, 2, 4, 5)]
         message(paste0("  ", utils::capture.output(print.data.frame(df, row.names = FALSE)),
-                       collapse = "\n"), "\n")
+          collapse = "\n"
+        ), "\n")
       }
     }
     message("")
@@ -964,12 +965,12 @@ tsbalancing <- function(in_ts,
 
 
   ### Main function ###
-  
+
   # Initialize the object to be returned by the function via `on.exit()`
   out_list <- NULL
   on.exit(return(out_list))
   warning_flag <- FALSE
-  
+
   # Enforce the default R "error" option (`options(error = NULL)`). E.g. this Turns off traceback
   # generated by calls to the stop() function inside internal functions in R Studio.
   ini_error_opt <- getOption("error")
@@ -980,8 +981,8 @@ tsbalancing <- function(in_ts,
   quiet <- gs.validate_arg_logi(quiet)
   if (quiet) {
     quiet_msg_func <- gs.NULL_func
-    quiet_lab <- ""  # won't be displayed anyway
-    displayLevel_lab <- ""  # won't be displayed anyway
+    quiet_lab <- "" # won't be displayed anyway
+    displayLevel_lab <- "" # won't be displayed anyway
     specs_display_func <- gs.NULL_func
     solve_msg_func <- gs.NULL_func
     osqp_verbose <- FALSE
@@ -992,7 +993,7 @@ tsbalancing <- function(in_ts,
   } else {
     quiet_msg_func <- message
     quiet_lab <- "    (*)quiet                 = FALSE (default)"
-    
+
     tmp <- (unlist(display_level))[1]
     if (!identical(display_level, tmp) || is.null(tmp) || !(tmp %in% 0:3)) {
       stop("Argument 'display_level' must take value 0, 1, 2, or 3.\n\n", call. = FALSE)
@@ -1037,16 +1038,9 @@ tsbalancing <- function(in_ts,
     }
   }
 
-  
+
   # Display the function header
   quiet_msg_func("\n\n", gs.header, "\n\ntsbalancing() function:\n")
-  
-  # Enforce the default R "error" option (`options(error = NULL)`). E.g. this Turns off traceback
-  # generated by calls to the stop() function inside internal functions in R Studio.
-  ini_error_opt <- getOption("error")
-  on.exit(options(error = ini_error_opt), add = TRUE)
-  options(error = NULL)
-
 
   # Initial argument validation
 
@@ -1070,7 +1064,7 @@ tsbalancing <- function(in_ts,
   time_values <- as.numeric(stats::time(in_ts))
   periods <- gs.time2str(in_ts)
   n_per <- length(periods)
-  
+
   specs_df_name <- deparse1(substitute(problem_specs_df))
   tmp <- nchar(specs_df_name)
   if (tmp == 0) {
@@ -1110,8 +1104,10 @@ tsbalancing <- function(in_ts,
   }
   if (lower_bound > upper_bound) {
     stop("Arguments `lower_bound` and 'upper_bound' are not compatible (`lower_bound = ",
-         format(lower_bound, big.mark = ","), " > ", format(upper_bound, big.mark = ","),
-         " = upper_bound`).\n\n", call. = FALSE)
+      format(lower_bound, big.mark = ","), " > ", format(upper_bound, big.mark = ","),
+      " = upper_bound`).\n\n",
+      call. = FALSE
+    )
   }
   tmp <- (unlist(tolV))[1]
   if (!identical(tolV, tmp) || is.null(tmp) || !is.finite(tmp) || is.finite(tmp) && tmp < 0) {
@@ -1155,7 +1151,6 @@ tsbalancing <- function(in_ts,
     tol_temporal_lab <- "    tolV_temporal            (ignored)"
     trunc_to_zero_tol <- NA_real_
     zero_trunc_lab <- "    (*)trunc_to_zero_tol     (ignored)"
-
   } else {
     valid_only_lab <- paste0("    (*)validation_only       = FALSE (default)")
     solve_func <- solve_one_osqp
@@ -1165,7 +1160,7 @@ tsbalancing <- function(in_ts,
     # Validate optional argument `temporal_grp_periodicity` (and set the header label)
     tmp <- (unlist(temporal_grp_periodicity))[1]
     if (!identical(temporal_grp_periodicity, tmp) || is.null(tmp) || !is.finite(tmp) ||
-        is.finite(tmp) && (tmp <= 0 || tmp != as.integer(tmp))) {
+      is.finite(tmp) && (tmp <= 0 || tmp != as.integer(tmp))) {
       stop("Argument 'temporal_grp_periodicity' must be a positive integer.\n\n", call. = FALSE)
     }
     temporal_grp_periodicity <- as.integer(temporal_grp_periodicity)
@@ -1181,20 +1176,20 @@ tsbalancing <- function(in_ts,
       tolP_temporal <- NA_real_
       tol_temporal_lab <- "    tolV_temporal            (ignored)"
     } else {
-
       # Validate optional argument `temporal_grp_start` (and set the header label)
       tmp <- (unlist(temporal_grp_start))[1]
       if (!identical(temporal_grp_start, tmp) || is.null(tmp) || !is.finite(tmp) ||
-          is.finite(tmp) && (tmp <= 0 || tmp > temporal_grp_periodicity || tmp != as.integer(tmp))) {
+        is.finite(tmp) && (tmp <= 0 || tmp > temporal_grp_periodicity || tmp != as.integer(tmp))) {
         stop("Argument 'temporal_grp_start' must be an integer in the [1..", temporal_grp_periodicity, "] interval.\n\n",
-             call. = FALSE)
+          call. = FALSE
+        )
       }
       temporal_grp_start <- as.integer(temporal_grp_start)
       temp_grp_start_lab <- paste0("    temporal_grp_start       = ", format(temporal_grp_start))
       if (temporal_grp_start == 1) {
         temp_grp_start_lab <- paste0(temp_grp_start_lab, " (default)")
       }
-      
+
       # Validate optional argument `alter_temporal`
       tmp <- (unlist(alter_temporal))[1]
       if (!identical(alter_temporal, tmp) || is.null(tmp) || !is.finite(tmp) || tmp < 0) {
@@ -1207,7 +1202,7 @@ tsbalancing <- function(in_ts,
       } else {
         alter_temporal_label <- "(arg `alter_temporal`)"
       }
-      
+
       # Validate the binding temporal total tolerances (and set the header label)
       tmp <- (unlist(tolV_temporal))[1]
       if (is.null(tmp)) {
@@ -1238,12 +1233,12 @@ tsbalancing <- function(in_ts,
         tolV_temporal <- 0
       }
     }
-    
+
     # Validate optional argument `osqp_settings_df` (and set the header label)
     settingsDF_lab <- "    osqp_settings_df         = "
     if (is.null(osqp_settings_df)) {
       settingsDF_lab <- paste0(settingsDF_lab, "NULL (default OSQP settings)")
-      # Set OSQP setting `verbose` (based on arguments `quiet` and `display_level`), 
+      # Set OSQP setting `verbose` (based on arguments `quiet` and `display_level`),
       # `require_polished = FALSE` and  `prior_scaling = FALSE`
       settings_df <- data.frame(verbose = osqp_verbose, require_polished = FALSE, prior_scaling = FALSE)
     } else {
@@ -1257,8 +1252,9 @@ tsbalancing <- function(in_ts,
       settings_df <- osqp_settings_df
       if (!is.data.frame(settings_df)) {
         warning("Argument 'settings_df_name' is not a 'data.frame' object. It will be ignored and the default OSQP ",
-                "settings sequence data frame (package data frame `default_osqp_sequence`) will be  used instead.\n",
-                call. = FALSE, immediate. = TRUE)
+          "settings sequence data frame (package data frame `default_osqp_sequence`) will be  used instead.\n",
+          call. = FALSE, immediate. = TRUE
+        )
         settings_df <- default_osqp_sequence
         settings_df_name <- "default_osqp_sequence"
       }
@@ -1284,12 +1280,12 @@ tsbalancing <- function(in_ts,
       } else {
         settings_df$require_polished <- FALSE
       }
-      # Set `prior_scaling` 
+      # Set `prior_scaling`
       if (!("prior_scaling" %in% settings_cols)) {
         settings_df$prior_scaling <- FALSE
       }
     }
-    
+
     # Validate the alterability coefficient optional arguments
     tmp <- (unlist(alter_pos))[1]
     if (!identical(alter_pos, tmp) || is.null(tmp) || !is.finite(tmp) || tmp < 0) {
@@ -1329,7 +1325,8 @@ tsbalancing <- function(in_ts,
     tmp <- (unlist(trunc_to_zero_tol))[1]
     if (!identical(trunc_to_zero_tol, tmp) || is.null(tmp) || !is.finite(tmp) || is.finite(tmp) && tmp < 0) {
       stop("Argument 'trunc_to_zero_tol' must be a nonnegative finite real number.\n\n",
-           call. = FALSE)
+        call. = FALSE
+      )
     }
     if (abs(trunc_to_zero_tol - validation_tol) < gs.tolerance) {
       zero_trunc_lab <- "    (*)trunc_to_zero_tol     = validation_tol (default)"
@@ -1383,26 +1380,26 @@ tsbalancing <- function(in_ts,
   quiet_msg_func(valid_only_lab)
   quiet_msg_func(quiet_lab, "\n")
   quiet_msg_func("    (*) indicates new arguments in G-Series 3.0\n")
-  
-  
-  # Build the core elements (building blocks) for the balancing problems (while validating the specified 
+
+
+  # Build the core elements (building blocks) for the balancing problems (while validating the specified
   # info), excluding the temporal totals info (will be added later, inside the processing groups loop):
-  #   - labels_df: cleaned-up version of the label definition records from `problem_specs_df` 
+  #   - labels_df: cleaned-up version of the label definition records from `problem_specs_df`
   #                (rows where `type` is non-missing); extra columns:
   #                  - type.lc : `tolower(type)`
-  #                  - row.lc  : `tolower(row)` 
+  #                  - row.lc  : `tolower(row)`
   #                  - con.flag: `type.lc %in% c("eq", "le", "ge")`
-  #   - coefs_df : cleaned-up version of the information specification records from `problem_specs_df` 
+  #   - coefs_df : cleaned-up version of the information specification records from `problem_specs_df`
   #                (rows where `type` is missing); extra columns:
-  #                  - row.lc  : `tolower(row)` 
+  #                  - row.lc  : `tolower(row)`
   #                  - con.flag: `labels_df$con.flag` allocated through `row.lc`
   #   - values_ts: reduced version of 'in_ts' with only the relevant series (see vector `ser_names`)
-  #   - lb       : lower bound info (`type.lc = "lowerbd"`) for the relevant series; list object with the 
+  #   - lb       : lower bound info (`type.lc = "lowerbd"`) for the relevant series; list object with the
   #                following elements:
   #                  - coefs_ts       : lower bound values for series and period
   #                  - nondated_coefs : vector of nondated lower bounds from `problem_specs_df` (`timeVal` is `NA`)
   #                  - nondated_id_vec: vector of `ser_names` id's associated to vector `nondated_coefs`
-  #                  - dated_id_vec   : vector of `ser_names` id's associated to dated lower bounds from 
+  #                  - dated_id_vec   : vector of `ser_names` id's associated to dated lower bounds from
   #                                     `problem_specs_df` (`timeVal` is not `NA`)
   #   - ub       : same as `lb` but for upper bounds (`type.lc = "upperbd"`)
   #   - alter    : same as `lb` but for period value alterability coefficients (`type.lc = "alter"`)
@@ -1410,33 +1407,33 @@ tsbalancing <- function(in_ts,
   #   - ser_names: vector of the relevant series names (set of series involved in the balancing constraints)
   #   - pos_ser  : vector of series names that have only positive coefficients across all balancing constraints
   #   - neg_ser  : vector of series names that have only negative coefficients across all balancing constraints
-  #   - mix_ser  : vector of series names that have both positive and negative coefficients across all balancing 
+  #   - mix_ser  : vector of series names that have both positive and negative coefficients across all balancing
   #                constraints
-  #   - A1,op1,b1: period level (single-period) balancing constraint elements (`A1 %*% x op1 b1` for 
+  #   - A1,op1,b1: period level (single-period) balancing constraint elements (`A1 %*% x op1 b1` for
   #                coherent/reconciled data)
-  #   - A2,op2,b2: temporal group level (multi-period) balancing constraint elements (`A2 %*% x op2 b2` for 
+  #   - A2,op2,b2: temporal group level (multi-period) balancing constraint elements (`A2 %*% x op2 b2` for
   #                coherent/reconciled data)
   #
   # Notes:
   #
-  #   - The returned balancing problem elements do not include the implicit temporal totals for multi-period 
+  #   - The returned balancing problem elements do not include the implicit temporal totals for multi-period
   #     processing (i.e., elements `A2`, `op2` and `b2` only contain the balancing constraints info).
-  #       
+  #
   #   - Multi-period balancing problem elements `A2`, `op2` and `b2` are constructed in "column-major order",
   #     corresponding to the default behaviour of R for converting matrices into vectors. E.g.:
   #       - single-period processing (period `t`):
   #           `A1 %*% as.vector(values_ts[t, ]) op1 b1` for coherent/reconciled data
   #       - multi-period processing (periods `t1:t2` of length `temporal_grp_periodicity`):
   #           `A2 %*% as.vector(values_ts[t1:t2, ]) op2 b2` for coherent/reconciled data
-  # 
-  #   - Default temporal total alterability coefficients (`altertmp$coefs_ts`) for cases not specified in the 
-  #     problem specs data frame (`problem_specs_df`) remain `NA` at this stage (i.e., argument `alter_temporal` 
+  #
+  #   - Default temporal total alterability coefficients (`altertmp$coefs_ts`) for cases not specified in the
+  #     problem specs data frame (`problem_specs_df`) remain `NA` at this stage (i.e., argument `alter_temporal`
   #     has not been used yet at this point). When time comes, this will allow for easy identification of the
   #     first specified (non `NA`) temporal total alter coef in the specs inside a complete temporal group.
-  # 
-  #   - A "wide range" of reserved keywords for column `type` in the specs (for label definition records) 
+  #
+  #   - A "wide range" of reserved keywords for column `type` in the specs (for label definition records)
   #     are accepted in practice (i.e., the list of accepted keywords, in lowercase, include):
-  #   - A "wide range" of reserved keywords for column `type` in the specs (for label definition records) 
+  #   - A "wide range" of reserved keywords for column `type` in the specs (for label definition records)
   #     are accepted in practice. The list of accepted keywords, in lowercase, include:
   #       - "==" and "=" for "eq"
   #       - "<=" and "<" for "le"
@@ -1445,40 +1442,42 @@ tsbalancing <- function(in_ts,
   #       - "upper" + ("" or "_" or "-" or "." or " ") + ("bd" or "bnd" or "bound) for "upperbd"
   #       - "alter" + ("" or "_" or "-" or "." or " ") + ("tmp" or "temp" or "temporal) for "altertmp"
   #
-  pb <- build_balancing_problem(in_ts                    = in_ts,
-                                problem_specs_df         = problem_specs_df,
-                                in_ts_name               = in_ts_name,
-                                ts_freq                  = ts_freq,
-                                periods                  = periods,
-                                n_per                    = n_per,
-                                specs_df_name            = specs_df_name,
-                                temporal_grp_periodicity = temporal_grp_periodicity,
-                                alter_pos                = alter_pos,
-                                alter_neg                = alter_neg,
-                                alter_mix                = alter_mix,
-                                lower_bound              = lower_bound, 
-                                upper_bound              = upper_bound,
-                                validation_only          = validation_only)
-  
+  pb <- build_balancing_problem(
+    in_ts = in_ts,
+    problem_specs_df = problem_specs_df,
+    in_ts_name = in_ts_name,
+    ts_freq = ts_freq,
+    periods = periods,
+    n_per = n_per,
+    specs_df_name = specs_df_name,
+    temporal_grp_periodicity = temporal_grp_periodicity,
+    alter_pos = alter_pos,
+    alter_neg = alter_neg,
+    alter_mix = alter_mix,
+    lower_bound = lower_bound,
+    upper_bound = upper_bound,
+    validation_only = validation_only
+  )
+
   # Number of series and balancing constraints
   n_ser <- length(pb$ser_names)
   n_con <- length(pb$labels_df$row.lc[pb$labels_df$con.flag])
-  
+
   # Display the problem specs info
   specs_display_func()
 
-    
+
   # Initial temporal aggregation matrix (for all series)
   #   => will be reduced later to the set of non fully binding series only
   #      (temporal totals of fully binding represent redundant constraints)
-  dim_A2 <- dim(pb$A2)  # `dim_A2[1]` = number of rows
+  dim_A2 <- dim(pb$A2) # `dim_A2[1]` = number of rows
   # `dim_A2[2]` = number of columns
   A_a <- matrix(0, nrow = n_ser, ncol = dim_A2[2] + n_ser)
   for (ii in 1:n_ser) {
     A_a[ii, ((ii - 1) * temporal_grp_periodicity + 1):(ii * temporal_grp_periodicity)] <- 1
     A_a[ii, dim_A2[2] + ii] <- -1
   }
-  
+
 
   # Define the processing groups (set of balancing problems).
   # Columns of the returned data frame:
@@ -1486,12 +1485,14 @@ tsbalancing <- function(in_ts,
   #   - beg_per     : first period id
   #   - end_per     : last period id
   #   - complete_grp: complete group flag (logical, TRUE if end_per != beg_per)
-  grp_df <- gs.build_proc_grps(gs.time2year(pb$values_ts),
-                               gs.time2per(pb$values_ts),
-                               n_per,
-                               ts_freq,
-                               temporal_grp_periodicity,
-                               temporal_grp_start)
+  grp_df <- gs.build_proc_grps(
+    gs.time2year(pb$values_ts),
+    gs.time2per(pb$values_ts),
+    n_per,
+    ts_freq,
+    temporal_grp_periodicity,
+    temporal_grp_start
+  )
 
   # Activate message display
   n_grps <- nrow(grp_df)
@@ -1510,8 +1511,10 @@ tsbalancing <- function(in_ts,
 
 
   # Initialize the output objects
-  out_mat <- matrix(NA_real_, nrow = n_per, ncol = n_ser,
-                    dimnames = list(NULL, pb$ser_names))
+  out_mat <- matrix(NA_real_,
+    nrow = n_per, ncol = n_ser,
+    dimnames = list(NULL, pb$ser_names)
+  )
   tmp1 <- rep.int(NA_character_, n_grps)
   tmp2 <- rep.int(NA_real_, n_grps)
   tmp3 <- rep.int(NA_integer_, n_grps)
@@ -1529,7 +1532,8 @@ tsbalancing <- function(in_ts,
     osqp_seqno = tmp3,
     osqp_status = tmp1,
     osqp_polished = rep.int(as.logical(NA), n_grps),
-    total_solve_time = tmp3)
+    total_solve_time = tmp3
+  )
   out_prob_val_df <- NULL
   out_prob_con_df <- NULL
   out_osqp_settings_df <- NULL
@@ -1538,7 +1542,6 @@ tsbalancing <- function(in_ts,
 
   # Balance each processing group (generate the `balancing_process()` calls)
   for (grp in 1:n_grps) {
-
     # Build the processing group header and balancing problem elements list
     per_id_vec <- grp_df$beg_per[grp]:grp_df$end_per[grp]
     n_per_grp <- length(per_id_vec)
@@ -1558,7 +1561,6 @@ tsbalancing <- function(in_ts,
     #   => balancing problem elements must be "augmented" with temporal total info
     #   => initial constraint elements are the "v2" objects
     if (grp_df$complete_grp[grp]) {
-
       out_proc_grp_df$proc_grp_type[grp] <- "temporal group"
       out_proc_grp_df$proc_grp_label[grp] <- paste0(periods[grp_df$beg_per[grp]], " - ", periods[grp_df$end_per[grp]])
 
@@ -1574,24 +1576,28 @@ tsbalancing <- function(in_ts,
       # Add the temporal totals info
       a <- A_a2[, 1:dim_A2[2], drop = FALSE] %*% bl$x
       bl$x <- c(bl$x, a)
-      c_a <- apply(pb$altertmp$coefs_ts[per_id_vec, pb$ser_names[non_fully_binding], drop = FALSE], 2,
-                   function(x) {
-                     # Return the first non missing (non `NA`) temporal total alter. coef. of the temporal group.
-                     # Otherwise (all `NA`), return the default alter. coef. (argument `alter_temporal`)
-                     y <- x[!is.na(x)][1]
-                     if (is.na(y)) {
-                       alter_temporal
-                     } else {
-                       y
-                     }
-                   })
+      c_a <- apply(
+        pb$altertmp$coefs_ts[per_id_vec, pb$ser_names[non_fully_binding], drop = FALSE], 2,
+        function(x) {
+          # Return the first non missing (non `NA`) temporal total alter. coef. of the temporal group.
+          # Otherwise (all `NA`), return the default alter. coef. (argument `alter_temporal`)
+          y <- x[!is.na(x)][1]
+          if (is.na(y)) {
+            alter_temporal
+          } else {
+            y
+          }
+        }
+      )
       bl$c <- c(bl$c, c_a)
       names(bl$c) <- NULL
       bl$lb <- c(bl$lb, rep.int(-Inf, n_a))
       bl$ub <- c(bl$ub, rep.int(Inf, n_a))
       bl$bd_tol <- c(bl$bd_tol, rep.int(0, n_a))
-      bl$A <- rbind(cbind(pb$A2, matrix(0, nrow = dim_A2[1], ncol = n_a)),
-                    A_a2)
+      bl$A <- rbind(
+        cbind(pb$A2, matrix(0, nrow = dim_A2[1], ncol = n_a)),
+        A_a2
+      )
       bl$op <- c(pb$op2, rep.int("==", n_a))
       bl$b <- c(pb$b2, rep.int(0, n_a))
 
@@ -1602,10 +1608,9 @@ tsbalancing <- function(in_ts,
       bl$b_tol <- c(rep.int(tolV, dim_A2[1]), (a * tolP_temporal + tolV_temporal) * (c_a == 0))
 
 
-    # Single-period processing
-    #   => constraint elements are the "v1" objects
+      # Single-period processing
+      #   => constraint elements are the "v1" objects
     } else {
-
       out_proc_grp_df$proc_grp_type[grp] <- "period"
       out_proc_grp_df$proc_grp_label[grp] <- periods[grp_df$beg_per[grp]]
 
@@ -1630,32 +1635,36 @@ tsbalancing <- function(in_ts,
 
     # Convert the balancing problem into a (reduced) QP problem (for OSQP):
     #   - construct the QP problem's Hessian matrix (`P`) and vector of linear coefficients (`q`)
-    #   - rewrite the balancing constraints as `l <= Ax <= u` linear constraints. transferring binding values 
+    #   - rewrite the balancing constraints as `l <= Ax <= u` linear constraints. transferring binding values
     #     (`c * x = 0`) into the constraints bounds (`l` and `u`)
     #   - add `l <= Ax <= u` linear constraints for and upper/lower bounds
-    qp <- build_reduced_qp(bl$x, bl$c, bl$lb, bl$ub, bl$bd_tol,  # problem variables info
-                           bl$A, bl$op, bl$b, bl$b_tol)          # problem constraints info
+    qp <- build_reduced_qp(
+      bl$x, bl$c, bl$lb, bl$ub, bl$bd_tol, # problem variables info
+      bl$A, bl$op, bl$b, bl$b_tol
+    ) # problem constraints info
     n_con_qp <- length(qp$l)
 
-    
+
     # Calculate the initial discrepancies
     Ax_ini <- qp$A %*% qp$x
     discr_ini <- calc_discr(Ax_ini, qp$l, qp$u)
-    
+
 
     # Solve the balancing problem
-    sol <- solve_func(x = qp$x,                                          # initial problem values (initial solution)
-                      Ax = Ax_ini,                                       # evaluated constraint body values with the initial solution
-                      discr = discr_ini,                                 # initial constraint discrepancies list
-                      validation_tol = validation_tol,                   # solution validation tolerance (max. allowed constraint discr.)
-                      P = qp$P, q = qp$q, A = qp$A, l = qp$l, u = qp$u,  # OSQP problem elements
-                      settings_df = settings_df,                         # OSQP settings sequence data frame
-                      full_sequence = full_sequence,                     # (logical) perform all steps (rows) of `settings_df`
-                      solve_msg_func = solve_msg_func,                   # (function) message display function
-                      osqpBeg_display_func = osqpBeg_display_func,       # (function) OSQP model and iterations display set up function
-                      osqpEnd_display_func = osqpEnd_display_func,       # (function) OSQP model and iterations display wrap up function
-                      osqp_output_file = osqp_output_file,               # temporary file (name and path) for the OSQP model and iterations contents
-                      trunc_to_zero_tol = trunc_to_zero_tol)             # tolerance for changing nonzero solution data points to 0
+    sol <- solve_func(
+      x = qp$x, # initial problem values (initial solution)
+      Ax = Ax_ini, # evaluated constraint body values with the initial solution
+      discr = discr_ini, # initial constraint discrepancies list
+      validation_tol = validation_tol, # solution validation tolerance (max. allowed constraint discr.)
+      P = qp$P, q = qp$q, A = qp$A, l = qp$l, u = qp$u, # OSQP problem elements
+      settings_df = settings_df, # OSQP settings sequence data frame
+      full_sequence = full_sequence, # (logical) perform all steps (rows) of `settings_df`
+      solve_msg_func = solve_msg_func, # (function) message display function
+      osqpBeg_display_func = osqpBeg_display_func, # (function) OSQP model and iterations display set up function
+      osqpEnd_display_func = osqpEnd_display_func, # (function) OSQP model and iterations display wrap up function
+      osqp_output_file = osqp_output_file, # temporary file (name and path) for the OSQP model and iterations contents
+      trunc_to_zero_tol = trunc_to_zero_tol
+    ) # tolerance for changing nonzero solution data points to 0
 
     # Set the balancing solution:
     #  - initial solution (`bl$x`) for binding values
@@ -1687,21 +1696,33 @@ tsbalancing <- function(in_ts,
     # Create the problem constraints info data frame
     prob_con_df <- data.frame(
       proc_grp = rep.int(grp, n_con_qp),
-      con_type = rep.int(c("balancing constraint",
-                           "temporal aggregation constraint",
-                           "period value bounds"),
-                         c(n_con * n_per_grp,
-                           n_a,
-                           length(qp$id_bd_con))),
-      name = c(rep(pb$labels_df$row[pb$labels_df$con.flag], each = n_per_grp),
-               pb$ser_names[non_fully_binding],
-               prob_val_df$name[qp$id_bd_con]),
-      t = c(rep.int(per_id_vec, n_con),
-            rep.int(per_id_vec[1], n_a),
-            prob_val_df$t[qp$id_bd_con]),
-      time_val = c(rep.int(time_values[per_id_vec], n_con),
-                   rep.int(time_values[per_id_vec[1]], n_a),
-                   prob_val_df$time_val[qp$id_bd_con]),
+      con_type = rep.int(
+        c(
+          "balancing constraint",
+          "temporal aggregation constraint",
+          "period value bounds"
+        ),
+        c(
+          n_con * n_per_grp,
+          n_a,
+          length(qp$id_bd_con)
+        )
+      ),
+      name = c(
+        rep(pb$labels_df$row[pb$labels_df$con.flag], each = n_per_grp),
+        pb$ser_names[non_fully_binding],
+        prob_val_df$name[qp$id_bd_con]
+      ),
+      t = c(
+        rep.int(per_id_vec, n_con),
+        rep.int(per_id_vec[1], n_a),
+        prob_val_df$t[qp$id_bd_con]
+      ),
+      time_val = c(
+        rep.int(time_values[per_id_vec], n_con),
+        rep.int(time_values[per_id_vec[1]], n_a),
+        prob_val_df$time_val[qp$id_bd_con]
+      ),
       l = qp$l,
       u = qp$u,
       Ax_in = as.vector(Ax_ini),
@@ -1727,47 +1748,61 @@ tsbalancing <- function(in_ts,
       out_proc_grp_df$osqp_status[grp] <- sol$osqp_info$status
       out_proc_grp_df$osqp_polished[grp] <- sol$osqp_info$status_polish == 1
       out_osqp_settings_df <- rbind(out_osqp_settings_df, as.data.frame(c(list(proc_grp = grp), sol$osqp_settings)))
-      out_osqp_sol_info_df <- rbind(out_osqp_sol_info_df,
-                                    as.data.frame(c(
-                                      list(proc_grp = grp),
-                                      sol$osqp_info,
-                                      # Calculate the original balancing problem's objective value
-                                      list(obj_val_ori_prob = 
-                                             sol$osqp_info$obj_val * sol$osqp_info$prior_scaling_factor  # original scale
-                                             + sum(-0.5 * qp$q * qp$x)))))                               # constant terms
+      out_osqp_sol_info_df <- rbind(
+        out_osqp_sol_info_df,
+        as.data.frame(c(
+          list(proc_grp = grp),
+          sol$osqp_info,
+          # Calculate the original balancing problem's objective value
+          list(
+            obj_val_ori_prob =
+              sol$osqp_info$obj_val * sol$osqp_info$prior_scaling_factor # original scale
+                + sum(-0.5 * qp$q * qp$x)
+          )
+        ))
+      ) # constant terms
     }
 
 
     # Sort, display and cumulate the problem values and constraints info data frames
-    prob_val_df <- prob_val_df[order(rep.int(1:2, c(n_values_grp, n_a)),
-                                     prob_val_df$t,
-                                     c(rep(1:n_ser, each = n_per_grp), seq_len(n_a)))
-                               , ]
+    prob_val_df <- prob_val_df[order(
+      rep.int(1:2, c(n_values_grp, n_a)),
+      prob_val_df$t,
+      c(rep(1:n_ser, each = n_per_grp), seq_len(n_a))
+    ), ]
     out_prob_val_df <- rbind(out_prob_val_df, prob_val_df)
     prob_con_df <- prob_con_df[order(
       # 1- constraint type (periods, then temporal totals)
-      rep.int(c(1, 2, 1), c(n_con * n_per_grp,
-                                  n_a,
-                                  length(qp$id_bd_con))),
+      rep.int(c(1, 2, 1), c(
+        n_con * n_per_grp,
+        n_a,
+        length(qp$id_bd_con)
+      )),
       # 2- period
       prob_con_df$t,
       # 3- constraint sub-type
-      rep.int(c(1, 3, 2), c(n_con * n_per_grp,
-                            n_a,
-                            length(qp$id_bd_con))),
+      rep.int(c(1, 3, 2), c(
+        n_con * n_per_grp,
+        n_a,
+        length(qp$id_bd_con)
+      )),
       # 4- constraint/series name (keeping this initial order)
-      c(rep(1:n_con, each = n_per_grp),
+      c(
+        rep(1:n_con, each = n_per_grp),
         seq_len(n_a),
-        seq_along(qp$id_bd_con)))
-      , ]
+        seq_along(qp$id_bd_con)
+      )
+    ), ]
     out_prob_con_df <- rbind(out_prob_con_df, prob_con_df)
     results_display_func()
-    
+
     # Validate the solution
     if (n_unmet > 0) {
       warning("Constraints were not met in ", n_unmet, " occasion(s). Maximum discrepancy: ",
-              format(sol$discr$max_discr, big.mark = ","), ". See constraints with `unmet_flag = TRUE` ",
-              "for details.\n", call. = FALSE, immediate. = TRUE)
+        format(sol$discr$max_discr, big.mark = ","), ". See constraints with `unmet_flag = TRUE` ",
+        "for details.\n",
+        call. = FALSE, immediate. = TRUE
+      )
       warning_flag <- TRUE
     }
   }
@@ -1783,7 +1818,8 @@ tsbalancing <- function(in_ts,
     # `sapply()` is safe: it always returns a numeric vector (`grp_df$grp` is of length minimum 1)
     proc_grp = rep.int(grp_df$grp, sapply(grp_df$grp, function(ii) length(grp_df$beg_per[ii]:grp_df$end_per[ii]))),
     t = 1:n_per,
-    time_val = time_values)
+    time_val = time_values
+  )
   row.names(out_prob_val_df) <- NULL
   out_list$prob_val_df <- out_prob_val_df
   row.names(out_prob_con_df) <- NULL
@@ -1796,7 +1832,8 @@ tsbalancing <- function(in_ts,
 
   if (final_msg_flag && warning_flag) {
     warning("Warnings were generated during processing. See relevant message(s) for details.\n",
-            call. = FALSE, immediate. = TRUE)
+      call. = FALSE, immediate. = TRUE
+    )
   }
 
   # Output object returned via function `on.exit()`
@@ -1807,65 +1844,65 @@ tsbalancing <- function(in_ts,
 #'
 #' @description
 #'
-#' \if{html,text}{(\emph{version française: 
+#' \if{html,text}{(\emph{version française:
 #' \url{https://StatCan.github.io/gensol-gseries/fr/reference/build_balancing_problem.html}})}
-#' 
-#' This function is used internally by [tsbalancing()] to build the elements of the balancing problems. 
-#' It can also be useful to derive the indirect series associated to equality balancing constraints manually 
-#' (outside of the [tsbalancing()] context). 
-#' 
-#' 
+#'
+#' This function is used internally by [tsbalancing()] to build the elements of the balancing problems.
+#' It can also be useful to derive the indirect series associated to equality balancing constraints manually
+#' (outside of the [tsbalancing()] context).
+#'
+#'
 #' @inheritParams tsbalancing
-#' 
-#' @param in_ts_name (optional) 
-#' 
+#'
+#' @param in_ts_name (optional)
+#'
 #' String containing the value of argument `in_ts`.
 #'
 #' **Default value** is `in_ts_name = deparse1(substitute(in_ts))`.
-#' 
+#'
 #' @param ts_freq (optional)
-#' 
+#'
 #' Frequency of the time series object (argument `in_ts`).
-#' 
+#'
 #' **Default value** is `ts_freq = stats::frequency(in_ts)`.
-#' 
-#' @param periods (optional) 
-#' 
+#'
+#' @param periods (optional)
+#'
 #' Character vector describing the time series object (argument `in_ts`) periods.
-#' 
+#'
 #' **Default value** is `periods = gs.time2str(in_ts)`.
-#' 
-#' @param n_per (optional) 
-#' 
+#'
+#' @param n_per (optional)
+#'
 #' Number of periods of the time series object (argument `in_ts`).
-#' 
+#'
 #' **Default value** is `n_per = nrow(as.matrix(in_ts))`.
-#' 
+#'
 #' @param specs_df_name (optional)
-#' 
+#'
 #' String containing the value of argument `problem_specs_df`.
-#' 
+#'
 #' **Default value** is `specs_df_name = deparse1(substitute(problem_specs_df))`.
-#' 
+#'
 #'
 #' @returns
 #' A list with the elements of the balancing problems (excluding the temporal totals info):
-#' - `labels_df`: cleaned-up version of the _label definition records_ from `problem_specs_df` 
+#' - `labels_df`: cleaned-up version of the _label definition records_ from `problem_specs_df`
 #'                (`type` is not missing (is not `NA`)); extra columns:
 #'   - `type.lc` : `tolower(type)`
-#'   - `row.lc`  : `tolower(row)` 
+#'   - `row.lc`  : `tolower(row)`
 #'   - `con.flag`: `type.lc %in% c("eq", "le", "ge")`
-#' - `coefs_df` : cleaned-up version of the information specification records from `problem_specs_df` 
+#' - `coefs_df` : cleaned-up version of the information specification records from `problem_specs_df`
 #'                (`type` is missing (is `NA`); extra columns:
-#'   - `row.lc`  : `tolower(row)` 
+#'   - `row.lc`  : `tolower(row)`
 #'   - `con.flag`: `labels_df$con.flag` allocated through `row.lc`
 #' - `values_ts`: reduced version of `in_ts` with only the relevant series (see vector `ser_names`)
-#' - `lb`       : lower bound info (`type.lc  = "lowerbd"`) for the relevant series; list object with the 
+#' - `lb`       : lower bound info (`type.lc  = "lowerbd"`) for the relevant series; list object with the
 #'                following elements:
 #'   - `coefs_ts`       : lower bound values for series and period
 #'   - `nondated_coefs` : vector of nondated lower bounds from `problem_specs_df` (`timeVal` is `NA`)
 #'   - `nondated_id_vec`: vector of `ser_names` id's associated to vector `nondated_coefs`
-#'   - `dated_id_vec`   : vector of `ser_names` id's associated to dated lower bounds from 
+#'   - `dated_id_vec`   : vector of `ser_names` id's associated to dated lower bounds from
 #'                        `problem_specs_df` (`timeVal` is not `NA`)
 #' - `ub`       : `lb` equivalent for upper bounds (`type.lc = "upperbd"`)
 #' - `alter`    : `lb` equivalent for period value alterability coefficients (`type.lc = "alter"`)
@@ -1873,40 +1910,40 @@ tsbalancing <- function(in_ts,
 #' - `ser_names`: vector of the relevant series names (set of series involved in the balancing constraints)
 #' - `pos_ser`  : vector of series names that have only positive nonzero coefficients across all balancing constraints
 #' - `neg_ser`  : vector of series names that have only negative nonzero coefficients across all balancing constraints
-#' - `mix_ser`  : vector of series names that have both positive and negative nonzero coefficients across all balancing 
+#' - `mix_ser`  : vector of series names that have both positive and negative nonzero coefficients across all balancing
 #'                constraints
-#' - `A1`,`op1`,`b1`: balancing constraint elements for problems involving a single period (e.g., each period of an 
+#' - `A1`,`op1`,`b1`: balancing constraint elements for problems involving a single period (e.g., each period of an
 #'                    incomplete temporal group)
-#' - `A2`,`op2`,`b2`: balancing constraint elements for problems involving `temporal_grp_periodicity` periods (e.g., the set 
+#' - `A2`,`op2`,`b2`: balancing constraint elements for problems involving `temporal_grp_periodicity` periods (e.g., the set
 #'                    of periods of a complete temporal group)
-#' 
-#' 
+#'
+#'
 #' @details
 #' See [tsbalancing()] for a detailed description of _time series balancing_ problems.
-#' 
-#' Any missing (`NA`) value found in the input time series object (argument `in_ts`) would be replaced with 0 in `values_ts` 
+#'
+#' Any missing (`NA`) value found in the input time series object (argument `in_ts`) would be replaced with 0 in `values_ts`
 #' and trigger a warning message.
-#' 
-#' The returned elements of the balancing problems do not include the implicit temporal totals (i.e., elements `A2`, `op2` 
+#'
+#' The returned elements of the balancing problems do not include the implicit temporal totals (i.e., elements `A2`, `op2`
 #' and `b2` only contain the balancing constraints).
-#'       
-#' Multi-period balancing problem elements `A2`, `op2` and `b2` (when `temporal_grp_periodicity > 1`) are constructed 
-#' _column by column_ (in "column-major order"), corresponding to the default behaviour of R for converting objects of class 
+#'
+#' Multi-period balancing problem elements `A2`, `op2` and `b2` (when `temporal_grp_periodicity > 1`) are constructed
+#' _column by column_ (in "column-major order"), corresponding to the default behaviour of R for converting objects of class
 #' "matrix" into vectors. I.e., the balancing constraints conceptually correspond to:
 #' - `A1 %*% values_ts[t, ] op1 b1` for problems involving a single period (`t`)
 #' - `A2 %*% as.vector(values_ts[t1:t2, ]) op2 b2` for problems involving `temporal_grp_periodicity` periods (`t1:t2`).
-#' 
-#' Note that argument `alter_temporal` has not been applied yet at this point and `altertmp$coefs_ts` only contains the 
-#' coefficients specified in the problem specs data frame (argument `problem_specs_df`). I.e., `altertmp$coefs_ts` contains 
-#' missing (`NA`) values except for the temporal total alterability coefficients included in (specified with) `problem_specs_df`. 
-#' This is done in order to simplify the identification of the first non missing (non `NA`) temporal total alterability 
+#'
+#' Note that argument `alter_temporal` has not been applied yet at this point and `altertmp$coefs_ts` only contains the
+#' coefficients specified in the problem specs data frame (argument `problem_specs_df`). I.e., `altertmp$coefs_ts` contains
+#' missing (`NA`) values except for the temporal total alterability coefficients included in (specified with) `problem_specs_df`.
+#' This is done in order to simplify the identification of the first non missing (non `NA`) temporal total alterability
 #' coefficient of each complete temporal group (to occur later, when applicable, inside [tsbalancing()]).
 #'
 #'
 #' @seealso [tsbalancing()] [build_raking_problem()]
-#' 
+#'
 #' @example misc/function_examples/build_balancing_problem-ex.R
-#' 
+#'
 #' @export
 build_balancing_problem <- function(in_ts,
                                     problem_specs_df,
@@ -1919,11 +1956,9 @@ build_balancing_problem <- function(in_ts,
                                     alter_pos = 1,
                                     alter_neg = 1,
                                     alter_mix = 1,
-                                    lower_bound = -Inf, 
+                                    lower_bound = -Inf,
                                     upper_bound = Inf,
                                     validation_only = FALSE) {
-  
-  
   # Assign non-constraint coefficients from the problem specs data frame.
   # Note: coefs with time values (`timeval`) outside the time series span are ignored
   #
@@ -1937,7 +1972,7 @@ build_balancing_problem <- function(in_ts,
   #   - n_per    : `nrow(coefs_ts)` = number of periods in the input 'ts' object
   #   - ts_freq  : `frequency(coefs_ts)` = frequency of the input 'ts' object
   #   - periods  : `gs.time2str(coefs_ts)` = vector of period string labels ("<year>-<per>")
-  # 
+  #
   # Value:
   #   Returns a list of 4 objects:
   #     - coefs_ts       : updated 'ts' object
@@ -1945,34 +1980,39 @@ build_balancing_problem <- function(in_ts,
   #     - nondated_id_vec: vector of `ser_names` id's associated to vector `nondated_coefs`
   #     - dated_id_vec   : vector of `ser_names` id's associated to dated coefficient (`timeval` is not `NA`)
   assign_coefs <- function(coefs_ts, label) {
-    
     # All periods (`timeval` is `NA`)
     logi_vec <- coefs_df$type.lc == label & is.na(coefs_df$timeval)
     coefs_ts[, coefs_df$col[logi_vec]] <- rep(coefs_df$coef[logi_vec], each = n_per)
-    
+
     # Specific periods (`timeval` is not `NA`)
     id_vec <- which(coefs_df$type.lc == label & !is.na(coefs_df$timeval))
     for (ii in seq_along(id_vec)) {
-      coefs_ts[match(gs.time2str(stats::ts(NA, start = coefs_df$timeval[id_vec[ii]], frequency = ts_freq)),
-                     periods, nomatch = 0),
-               coefs_df$col[id_vec[ii]]] <- coefs_df$coef[id_vec[ii]]
+      coefs_ts[
+        match(gs.time2str(stats::ts(NA, start = coefs_df$timeval[id_vec[ii]], frequency = ts_freq)),
+          periods,
+          nomatch = 0
+        ),
+        coefs_df$col[id_vec[ii]]
+      ] <- coefs_df$coef[id_vec[ii]]
     }
-    
-    list(coefs_ts = coefs_ts,
-         nondated_coefs = coefs_df$coef[logi_vec],
-         nondated_id_vec = match(coefs_df$col[logi_vec], ser_names),
-         dated_id_vec = match(unique(coefs_df$col[id_vec]), ser_names))
+
+    list(
+      coefs_ts = coefs_ts,
+      nondated_coefs = coefs_df$coef[logi_vec],
+      nondated_id_vec = match(coefs_df$col[logi_vec], ser_names),
+      dated_id_vec = match(unique(coefs_df$col[id_vec]), ser_names)
+    )
   }
-  
-  
+
+
   ### Main function ###
 
-  
+
   # Initial clean-up/standardization of the problem specs df:
   #   - convert column names to lowercase
   #   - replace empty strings ("") with `NA` for character columns (`type`, `col`, `row`)
   #   - standardize constraint RHS specification (`col = "_rhs_"`)
-  #   - add column `timeval` if not present 
+  #   - add column `timeval` if not present
   #     => if column `time_val` is present (without column `timeval`), it is recoded to `timeval`
   in_ts_cols <- colnames(in_ts)
   specsDF_cols <- tolower(names(problem_specs_df))
@@ -1983,7 +2023,9 @@ build_balancing_problem <- function(in_ts,
   logi_vec <- sapply(core_cols[1:3], function(col) !is.character(problem_specs_df[[col]]))
   if (any(logi_vec)) {
     stop("The following problem specs data frame column(s) must be character:",
-         paste0("\n  ", core_cols[c(logi_vec, FALSE)], collapse = ""), call. = FALSE)
+      paste0("\n  ", core_cols[c(logi_vec, FALSE)], collapse = ""),
+      call. = FALSE
+    )
   }
   if (!is.numeric(problem_specs_df$coef)) {
     stop("Problem specs data frame column `coef` must be numeric.", call. = FALSE)
@@ -2009,29 +2051,33 @@ build_balancing_problem <- function(in_ts,
       }
       if (any(!is.finite(problem_specs_df$timeval[logi_vec]))) {
         stop("Invalid time values (column `timeVal`) found in the problem specs data frame (time values must be ",
-             "finite real numbers or `NA`).", call. = FALSE)
+          "finite real numbers or `NA`).",
+          call. = FALSE
+        )
       }
     } else {
       problem_specs_df$timeval <- NA_real_
     }
   }
-  
-  
+
+
   # Split specs data frame into labels and coefs data frames
   labels_df <- problem_specs_df[!is.na(problem_specs_df$type), c("type", "row"), drop = FALSE]
   coefs_df <- problem_specs_df[is.na(problem_specs_df$type), c("col", "row", "coef", "timeval"), drop = FALSE]
-  
+
   # Initial (basic) problems specs validation
   if (any(is.na(labels_df$row))) {
     stop("Invalid label definition record found in the problem specs data frame (missing `row` value).", call. = FALSE)
   }
   if (any(is.na(coefs_df$col) | is.na(coefs_df$row))) {
     stop("Invalid information specification record found in the problem specs data frame ",
-         "(missing `col` or `row` value).", call. = FALSE)
+      "(missing `col` or `row` value).",
+      call. = FALSE
+    )
   }
   # Reject (ignore) missing (`NA`) coefs
   coefs_df <- coefs_df[!is.na(coefs_df$coef), , drop = FALSE]
-  
+
   # Cleanup the labels (lowercase version of columns `type` and `row`)
   # => Allow the following lowercase `type` values (convert them to the expected lowercase value):
   #    - "==" and "=" for "eq"
@@ -2040,27 +2086,36 @@ build_balancing_problem <- function(in_ts,
   #    - "lower" + ("" or "_" or "-" or "." or " ") + ("bd" or "bnd" or "bound) for "lowerbd"
   #    - "upper" + ("" or "_" or "-" or "." or " ") + ("bd" or "bnd" or "bound) for "upperbd"
   #    - "alter" + ("" or "_" or "-" or "." or " ") + ("tmp" or "temp" or "temporal) for "altertmp"
-  labels_df$type.lc <- sub(sub(sub(sub(sub(tolower(labels_df$type), 
-                                           pattern = "^(==|=)$", 
-                                           replacement = "eq", 
-                                           perl = TRUE),
-                                       pattern = "^(<=|<)$", 
-                                       replacement = "le", 
-                                       perl = TRUE),
-                                   pattern = "^(>=|>)$", 
-                                   replacement = "ge", 
-                                   perl = TRUE),
-                               pattern = "^(lower|upper)[\\.[:blank:]_-]?(bd|bnd|bound)$", 
-                               replacement = "\\1bd", 
-                               perl = TRUE),
-                           pattern = "^alter[\\.[:blank:]_-]?(tmp|temp|temporal)$", 
-                           replacement = "altertmp", 
-                           perl = TRUE)
+  labels_df$type.lc <- sub(
+    sub(
+      sub(
+        sub(
+          sub(tolower(labels_df$type),
+            pattern = "^(==|=)$",
+            replacement = "eq",
+            perl = TRUE
+          ),
+          pattern = "^(<=|<)$",
+          replacement = "le",
+          perl = TRUE
+        ),
+        pattern = "^(>=|>)$",
+        replacement = "ge",
+        perl = TRUE
+      ),
+      pattern = "^(lower|upper)[\\.[:blank:]_-]?(bd|bnd|bound)$",
+      replacement = "\\1bd",
+      perl = TRUE
+    ),
+    pattern = "^alter[\\.[:blank:]_-]?(tmp|temp|temporal)$",
+    replacement = "altertmp",
+    perl = TRUE
+  )
   labels_df$row.lc <- tolower(labels_df$row)
   coefs_df$row.lc <- tolower(coefs_df$row)
   labels_df$con.flag <- labels_df$type.lc %in% c("eq", "le", "ge")
   coefs_df$con.flag <- coefs_df$row.lc %in% unique(labels_df$row.lc[labels_df$con.flag])
-  
+
   # Get the list of series involved in balancing constraints
   ser_names <- unique(coefs_df$col[coefs_df$con.flag & coefs_df$col != "_rhs_" & coefs_df$coef != 0])
   n_ser <- length(ser_names)
@@ -2070,62 +2125,75 @@ build_balancing_problem <- function(in_ts,
   missing_cols <- setdiff(ser_names, in_ts_cols)
   if (length(missing_cols) > 0) {
     stop("The following series, listed in balancing constraints in the problem specs data frame, are missing from ",
-         "input 'ts' object \"", in_ts_name, "\": ", paste0("\n  ", missing_cols, collapse = ""), call. = FALSE)
+      "input 'ts' object \"", in_ts_name, "\": ", paste0("\n  ", missing_cols, collapse = ""),
+      call. = FALSE
+    )
   }
   # Order `ser_names` according to the input time series columns
   ser_names <- intersect(in_ts_cols, ser_names)
-  
+
   # Keep only the relevant info from the problem specification data frame: info related to the
   # "balancing problem series", i.e., the set of series involved in the balancing constraint.
   coefs_df <- coefs_df[
     # coefs of relevant series (involved in balancing constraints)
     coefs_df$col %in% ser_names & (!coefs_df$con.flag | coefs_df$con.flag & coefs_df$coef != 0)
     # RHS values for relevant constraints (involving at least one series)
-    | coefs_df$col == "_rhs_" & coefs_df$row.lc %in% unique(coefs_df$row.lc[coefs_df$con.flag & coefs_df$col %in% ser_names])
-    , , drop = FALSE]
+    | coefs_df$col == "_rhs_" & coefs_df$row.lc %in% unique(coefs_df$row.lc[coefs_df$con.flag & coefs_df$col %in% ser_names]),
+    ,
+    drop = FALSE
+  ]
   row.names(coefs_df) <- NULL
   labels_df <- labels_df[labels_df$row.lc %in% unique(coefs_df$row.lc), , drop = FALSE]
   row.names(labels_df) <- NULL
-  
+
   # Bring the type labels in the coefs data frame
   coefs_df <- merge(labels_df[c("type.lc", "row.lc")], coefs_df, by = "row.lc", all = TRUE, sort = FALSE)
-  
-  
+
+
   # Extra problems specs validation (more in-depth validation for the remaining relevant info)
-  
+
   # Invalid problem elements
   invalid_types <- setdiff(unique(labels_df$type.lc), c("eq", "le", "ge", "lowerbd", "upperbd", "alter", "altertmp"))
   if (length(invalid_types) > 0) {
     stop("The following invalid problem elements ('type' column values in lowercase) were found in the problem specs data frame: ",
-         paste0("\n  ", invalid_types, collapse = ""), call. = FALSE)
+      paste0("\n  ", invalid_types, collapse = ""),
+      call. = FALSE
+    )
   }
-  
+
   # Invalid labels
   invalid_labels <- unique(coefs_df$row.lc[is.na(coefs_df$type.lc)])
   if (length(invalid_labels) > 0) {
     stop("The following labels ('row' column values in lowercase) in the problem specs data frame have not been properly ",
-         "defined (no coresponding \"label definition record\"): ", paste0("\n  ", invalid_labels, collapse = ""),
-         call. = FALSE)
+      "defined (no coresponding \"label definition record\"): ", paste0("\n  ", invalid_labels, collapse = ""),
+      call. = FALSE
+    )
   }
-  
+
   # Duplicate labels
   if (any(table(labels_df$row.lc) > 1)) {
     stop("The problem specs data frame contains duplicate labels, i.e., same 'row' value used for several ",
-         "problem elements (`type` values).", call. = FALSE)
+      "problem elements (`type` values).",
+      call. = FALSE
+    )
   }
-  
+
   # Duplicate label definition records for non-constraint elements
   if (any(table(labels_df$type.lc[!labels_df$con.flag]) > 1)) {
     stop("The problem specs data frame contains duplicate label definition records for non-constraint elements ",
-         "(i.e., a given non-constraint `type` value is assigned a `row` value more than once).", call. = FALSE)
+      "(i.e., a given non-constraint `type` value is assigned a `row` value more than once).",
+      call. = FALSE
+    )
   }
-  
+
   # Specified time values (`timeval`) for constraints
   if (any(coefs_df$con.flag & !is.na(coefs_df$timeval))) {
     stop("Time values (column `timeVal` in the problem specs data frame) cannot be specified for constraint ",
-         "coefficients or RHS values.", call. = FALSE)
+      "coefficients or RHS values.",
+      call. = FALSE
+    )
   }
-  
+
   # Invalid numeric `coef` values:
   #   - constraint coefficients  : infinite
   #   - alterability coefficients: negative or infinite
@@ -2133,39 +2201,49 @@ build_balancing_problem <- function(in_ts,
   #   - upper bound              : -Inf
   if (any(!is.finite(coefs_df$coef[coefs_df$con.flag]))) {
     stop("Invalid constraint coefficients (column `coef`) found in the problem specs data frame (constraint ",
-         "coefficients must be finite real numbers).", call. = FALSE)
+      "coefficients must be finite real numbers).",
+      call. = FALSE
+    )
   }
   logi_vec <- (coefs_df$type.lc %in% c("alter", "altertmp"))
   if (any(!is.finite(coefs_df$coef[logi_vec]) | coefs_df$coef[logi_vec] < 0)) {
     stop("Invalid alterability coefficients (column `coef`) found in the problem specs data frame (alterability ",
-         "coefficients must be nonnegative finite real numbers).", call. = FALSE)
+      "coefficients must be nonnegative finite real numbers).",
+      call. = FALSE
+    )
   }
   if (any(coefs_df$coef[coefs_df$type.lc == "lowerbd"] == Inf)) {
     stop("Invalid period value lower bounds (column `coef`) found in the problem specs data frame (lower bounds ",
-         "must be a finite real number or -Inf).", call. = FALSE)
+      "must be a finite real number or -Inf).",
+      call. = FALSE
+    )
   }
   if (any(coefs_df$coef[coefs_df$type.lc == "upperbd"] == -Inf)) {
     stop("Invalid period value upper bounds (column `coef`) found in the problem specs data frame (upper bounds ",
-         "must be a finite real number or Inf).", call. = FALSE)
+      "must be a finite real number or Inf).",
+      call. = FALSE
+    )
   }
-  
+
   # Duplicate coefficient specification
   if (any(table(coefs_df[c("col", "row.lc", "timeval")], useNA = "always") > 1)) {
     stop("The problem specs data frame contains duplicate information specification records, i.e., multiple 'coef' values ",
-         "for a given set of `col` (time series or constraint RHS), `row` (problem element) and 'timeVal' values.",
-         call. = FALSE)
+      "for a given set of `col` (time series or constraint RHS), `row` (problem element) and 'timeVal' values.",
+      call. = FALSE
+    )
   }
-  
+
   # 'Reduce the input 'ts' 'in_ts' version with only the relevant series
   values_ts <- in_ts[, ser_names, drop = FALSE]
   logi_vec <- is.na(values_ts)
   if (sum(logi_vec) > 0) {
     warning("Missing data were found in the input 'ts' object. They were replaced with 0.",
-            call. = FALSE, immediate. = TRUE)
+      call. = FALSE, immediate. = TRUE
+    )
     values_ts[logi_vec] <- 0
   }
-  
-  
+
+
   # Assign the lower/upper bounds
   lb <- list(coefs_ts = values_ts)
   lb$coefs_ts[, ] <- lower_bound
@@ -2175,15 +2253,16 @@ build_balancing_problem <- function(in_ts,
   ub <- assign_coefs(ub$coefs_ts, "upperbd")
   if (any(lb$coefs_ts > ub$coefs_ts)) {
     stop("Incompatible period value bounds (column `coef`) specified in the problem specs data frame (lower bounds ",
-         "cannot be greater than upper bounds).", call. = FALSE)
+      "cannot be greater than upper bounds).",
+      call. = FALSE
+    )
   }
-  
+
   # Assign the alterability coefficients
   alter <- list(coefs_ts = values_ts)
   alter$coefs_ts[, ] <- NA_real_
   altertmp <- alter
   if (!validation_only) {
-    
     # Default (function arguments `alter_pos`, `alter_neg` and `alter_mix`)
     pos_ser <- unique(coefs_df$col[coefs_df$con.flag & coefs_df$col != "_rhs_" & coefs_df$coef > 0])
     neg_ser <- unique(coefs_df$col[coefs_df$con.flag & coefs_df$col != "_rhs_" & coefs_df$coef < 0])
@@ -2193,29 +2272,32 @@ build_balancing_problem <- function(in_ts,
     alter$coefs_ts[, pos_ser] <- alter_pos
     alter$coefs_ts[, neg_ser] <- alter_neg
     alter$coefs_ts[, mix_ser] <- alter_mix
-    
+
     # From the problem specs data frame
     alter <- assign_coefs(alter$coefs_ts, "alter")
     altertmp <- assign_coefs(altertmp$coefs_ts, "altertmp")
-    # Note: as opposed to the period value alter coefs (`alter$coefs_ts`), the default temporal total 
-    #       alterability coefficients (`altertmp$coefs_ts`) for cases not specified in the problem specs 
+    # Note: as opposed to the period value alter coefs (`alter$coefs_ts`), the default temporal total
+    #       alterability coefficients (`altertmp$coefs_ts`) for cases not specified in the problem specs
     #       data frame remain `NA` for now (i.e., argument `alter_temporal` is not used right away).
-    #       This will allow for easy identification of the first specified temporal total alter coef in the specs 
+    #       This will allow for easy identification of the first specified temporal total alter coef in the specs
     #       (when applicable) inside a complete temporal group.
-    
   } else {
     pos_ser <- character(0L)
     neg_ser <- character(0L)
     mix_ser <- character(0L)
-    alter <- c(alter, list(nondated_coefs = numeric(0L),
-                           nondated_id_vec = integer(0L),
-                           dated_id_vec = integer(0L)))
-    altertmp <- c(altertmp, list(nondated_coefs = numeric(0L),
-                                 nondated_id_vec = integer(0L),
-                                 dated_id_vec = integer(0L)))
+    alter <- c(alter, list(
+      nondated_coefs = numeric(0L),
+      nondated_id_vec = integer(0L),
+      dated_id_vec = integer(0L)
+    ))
+    altertmp <- c(altertmp, list(
+      nondated_coefs = numeric(0L),
+      nondated_id_vec = integer(0L),
+      dated_id_vec = integer(0L)
+    ))
   }
-  
-  
+
+
   # Build the initial version of problem constraints elements:
   #   - matrix `A` : balancing constraint coefficients matrix
   #   - vector `op`: balancing constraint operator strings ("==", "<=" or ">=")
@@ -2249,26 +2331,28 @@ build_balancing_problem <- function(in_ts,
   op1[op1 == "le"] <- "<="
   op1[op1 == "ge"] <- ">="
   op2 <- op1[rep(1:n_con, each = temporal_grp_periodicity)]
-  
-  
+
+
   # Return the balancing problem core elements (building blocks)
-  list(labels_df = labels_df,
-       coefs_df = coefs_df,
-       values_ts = values_ts,
-       lb = lb,
-       ub = ub,
-       alter = alter,
-       altertmp = altertmp,
-       ser_names = ser_names,
-       pos_ser = pos_ser,
-       neg_ser = neg_ser,
-       mix_ser = mix_ser,
-       A1 = A1,
-       op1 = op1,
-       b1 = b1,
-       A2 = A2,
-       op2 = op2,
-       b2 = b2)
+  list(
+    labels_df = labels_df,
+    coefs_df = coefs_df,
+    values_ts = values_ts,
+    lb = lb,
+    ub = ub,
+    alter = alter,
+    altertmp = altertmp,
+    ser_names = ser_names,
+    pos_ser = pos_ser,
+    neg_ser = neg_ser,
+    mix_ser = mix_ser,
+    A1 = A1,
+    op1 = op1,
+    b1 = b1,
+    A2 = A2,
+    op2 = op2,
+    b2 = b2
+  )
 }
 
 
@@ -2299,11 +2383,11 @@ build_balancing_problem <- function(in_ts,
 #'   - id_bd_con: id's of input vector `x` corresponding to the lower/upper bound constraints
 #'
 #' @details
-#' The returned QP problem corresponds the balancing problem in its "reduced form" where binding values 
-#' (`c * x = 0`) are removed from the problem and transferred into the constraints bounds (`l` and `u`) 
-#' instead. 
-#' 
-#' Construct the reduced QP problem's Hessian matrix (`P`) and vector of linear coefficients (`q`), 
+#' The returned QP problem corresponds the balancing problem in its "reduced form" where binding values
+#' (`c * x = 0`) are removed from the problem and transferred into the constraints bounds (`l` and `u`)
+#' instead.
+#'
+#' Construct the reduced QP problem's Hessian matrix (`P`) and vector of linear coefficients (`q`),
 #' rewrite the balancing constraints as `l <= Ax <= u` linear constraints, i.e.,
 #'   - `l = b - b_tol` and `u = b + b_tol` for "==" constraints,
 #'   - `l = -Inf` and `u = b + b_tol` for "<=" constraints,
@@ -2312,14 +2396,14 @@ build_balancing_problem <- function(in_ts,
 #'   - `l = lb - bd_tol` and `u = Inf` for lower bounds (w/o upper bounds),
 #'   - `l = -Inf` and `u = ub + bd_tol` for upper bounds (w/o lower bounds),
 #'   - `l = lb - bd_tol` and `u = ub + bd_tol` for both lower AND upper bounds.
-#'   
-#' Fixed QP problems (`validation_only = TRUE` or all values of `x` are binding) have missing (`NA`) values 
+#'
+#' Fixed QP problems (`validation_only = TRUE` or all values of `x` are binding) have missing (`NA`) values
 #' for `P` and `q` and should not be sent to OSQP (the initial solution should be returned).
 #'
 #' @noRd
-build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
-                             A, op, b, b_tol) {     # problem constraints info
-  
+build_reduced_qp <- function(x, c, lb, ub, bd_tol, # problem variables info
+                             A, op, b, b_tol) { # problem constraints info
+
   # Initial number of constraints (`dim_A[1]`) and variables (`dim_A[2]`)
   dim_A <- dim(A)
 
@@ -2337,13 +2421,13 @@ build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
     b <- b - A[, !logi_vec, drop = FALSE] %*% x[!logi_vec]
     A <- A[, id_x, drop = FALSE]
     dim_A[2] <- length(id_x)
-    
+
     # QP problem quadratic coefficients (Hessian) matrix and vector of linear coefficients
     w <- 1 / abs(c[id_x] * x[id_x])
     P <- diag(2 * w, nrow = dim_A[2])
     q <- -2 * w * x[id_x]
 
-  # Fixed problem (`validation_only = TRUE` or all values are binding) => do not reduce the problem
+    # Fixed problem (`validation_only = TRUE` or all values are binding) => do not reduce the problem
   } else {
     id_x <- seq_along(x)
 
@@ -2360,7 +2444,7 @@ build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
   l[logi_vec] <- b[logi_vec] - b_tol[logi_vec]
   logi_vec <- op != ">="
   u[logi_vec] <- b[logi_vec] + b_tol[logi_vec]
-  
+
   # Add constraints for period value lower/upper bounds.
   logi_vec <- lb[id_x] != -Inf | ub[id_x] != Inf
   if (any(logi_vec)) {
@@ -2370,30 +2454,32 @@ build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
     id_bd <- which(logi_vec)
     id_bd_con <- id_x[id_bd]
     n_bd <- length(id_bd)
-    
+
     # Initial transposed matrix (0 values) for the new rows (new columns in this transposed matrix)
     tmp_mat <- matrix(0, nrow = dim_A[2], ncol = n_bd)
-    
+
     # Set the proper matrix elements to 1 (column-major order)
     tmp_mat[id_bd + seq.int(from = 0, by = dim_A[2], length.out = n_bd)] <- 1
-    
+
     # Add the new constraints
     A <- rbind(A, t(tmp_mat))
-    l <- c(l, lb[id_bd_con] - bd_tol[id_bd_con])  # `-Inf` minus any value remains `-Inf`
-    u <- c(u, ub[id_bd_con] + bd_tol[id_bd_con])  #  `Inf`  plus any value remains  `Inf`
+    l <- c(l, lb[id_bd_con] - bd_tol[id_bd_con]) # `-Inf` minus any value remains `-Inf`
+    u <- c(u, ub[id_bd_con] + bd_tol[id_bd_con]) #  `Inf`  plus any value remains  `Inf`
   } else {
     id_bd_con <- integer(0L)
   }
 
   # Return the reduced QP problem info
-  list(P = P,
-       q = q,
-       A = A,
-       l = l,
-       u = u,
-       x = x[id_x],
-       id_x = id_x,
-       id_bd_con = id_bd_con)
+  list(
+    P = P,
+    q = q,
+    A = A,
+    l = l,
+    u = u,
+    x = x[id_x],
+    id_x = id_x,
+    id_bd_con = id_bd_con
+  )
 }
 
 
@@ -2413,8 +2499,8 @@ build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
 #'
 #' @details
 #' Compare the evaluated constraints body (`Ax`) against the constraints bounds
-#' (`l` and `u`). Discrepancies are positive values representing constraint bounds 
-#' *violations*. A discrepancy of 0 means that the corresponding constraint bounds 
+#' (`l` and `u`). Discrepancies are positive values representing constraint bounds
+#' *violations*. A discrepancy of 0 means that the corresponding constraint bounds
 #' are fully respected.
 #'   - Equality (`==`) constraints have `l = u`
 #'   - Inequality (`<=` or `>=`) constraints either have `l = -Inf` or `u = Inf`
@@ -2422,16 +2508,17 @@ build_reduced_qp <- function(x, c, lb, ub, bd_tol,  # problem variables info
 #'
 #' @noRd
 calc_discr <- function(Ax, l, u) {
-  
   discr_vec <- pmax.int(l - Ax, Ax - u, 0)
-  list(discr_vec = discr_vec,
-       max_discr = max(discr_vec),
-       tot_discr = sum(discr_vec))
+  list(
+    discr_vec = discr_vec,
+    max_discr = max(discr_vec),
+    tot_discr = sum(discr_vec)
+  )
 }
 
 
 #' Return the Initial Solution
-#' 
+#'
 #' @description
 #' Do not solve the balancing problem. Simply return the initial solution info.
 #'
@@ -2463,9 +2550,8 @@ return_initial_sol <- function(x,
                                discr,
                                validation_tol,
                                ...) {
-
   start_time <- Sys.time()
-  
+
   if (discr$max_discr <= validation_tol) {
     status <- "valid initial solution"
     status_val <- 1
@@ -2473,23 +2559,25 @@ return_initial_sol <- function(x,
     status <- "invalid initial solution"
     status_val <- -1
   }
-  
-  list(x = x,
-       status = status,
-       status_val = status_val,
-       Ax = Ax,
-       discr = discr,
-       type = "initial",
-       osqp_attempts = 0,
-       osqp_seqno = NA_integer_,
-       osqp_settings = NULL,
-       osqp_info = NULL,
-       seq_time = Sys.time() - start_time)
+
+  list(
+    x = x,
+    status = status,
+    status_val = status_val,
+    Ax = Ax,
+    discr = discr,
+    type = "initial",
+    osqp_attempts = 0,
+    osqp_seqno = NA_integer_,
+    osqp_settings = NULL,
+    osqp_info = NULL,
+    seq_time = Sys.time() - start_time
+  )
 }
 
 
 #' Solve the balancing problem
-#' 
+#'
 #' @description
 #' Solve a single balancing problem with OSQP.
 #'
@@ -2505,7 +2593,7 @@ return_initial_sol <- function(x,
 #' @param osqpEnd_display_func (function) OSQP model and iterations display wrap up function.
 #' @param osqp_output_file (string) temporary file (name and path) for the OSQP model and iterations contents.
 #' @param trunc_to_zero_tol (double) tolerance for changing nonzero solution data points to 0.
-#' 
+#'
 #' @return a list with the following elements elements:
 #'   - `x`: (double vector) final solution.
 #'   - `status`: (string) solution status description.
@@ -2524,13 +2612,13 @@ return_initial_sol <- function(x,
 #'
 #' The settings data frame (argument `settings_df`) dictates the total number of attempts made
 #' at solving the problem. Each attempt is made with the list of OSQP settings for the corresponding
-#' `settings_df` observation (row). Unless a full sequence is specified (argument `full_sequence = TRUE`), 
-#' the solving sequence stops as soon as a valid solution is obtained (a solution for which all constraint 
-#' discrepancies are smaller or equal to the tolerance specified with argument `validation_tol`) unless setting 
-#' `require_polished = TRUE` is specified in the settings data frame for that step, in which case a polished 
-#' solution from OSQP (`status_polish = 1`) would also be required to stop the sequence. 
-#' 
-#' Note that the constraint discrepancies are calculated on the *zero truncated* solution values, when applicable 
+#' `settings_df` observation (row). Unless a full sequence is specified (argument `full_sequence = TRUE`),
+#' the solving sequence stops as soon as a valid solution is obtained (a solution for which all constraint
+#' discrepancies are smaller or equal to the tolerance specified with argument `validation_tol`) unless setting
+#' `require_polished = TRUE` is specified in the settings data frame for that step, in which case a polished
+#' solution from OSQP (`status_polish = 1`) would also be required to stop the sequence.
+#'
+#' Note that the constraint discrepancies are calculated on the *zero truncated* solution values, when applicable
 #' (i.e., when argument `trunc_to_zero_tol > 0`), therefore ensuring accurate validation of the final solution.
 #'
 #' @noRd
@@ -2546,20 +2634,19 @@ solve_one_osqp <- function(x,
                            osqpEnd_display_func,
                            osqp_output_file,
                            trunc_to_zero_tol) {
-
-
   start_time <- Sys.time()
-  
-  # Print the initial solution discrepancies
-  solve_msg_func("  Initial solution:\n    - Maximum discrepancy = ", format(discr$max_discr, big.mark = ","),
-                 "\n    - Total discrepancy   = ", format(discr$tot_discr, big.mark = ","), "\n")
 
-  
+  # Print the initial solution discrepancies
+  solve_msg_func(
+    "  Initial solution:\n    - Maximum discrepancy = ", format(discr$max_discr, big.mark = ","),
+    "\n    - Total discrepancy   = ", format(discr$tot_discr, big.mark = ","), "\n"
+  )
+
+
   # No initial discrepancies: return the initial solution
   if (discr$tot_discr <= gs.min_tolerance) {
-    
     solve_msg_func("  No discrepancies. Returning the intial values.\n")
-    
+
     status <- "valid initial solution"
     status_val <- 1
     type <- "initial"
@@ -2568,18 +2655,21 @@ solve_one_osqp <- function(x,
     osqp_settings <- NULL
     osqp_info <- NULL
 
-    
-  # Fixed problem (all values are either 0 or binding): return the initial solution
+
+    # Fixed problem (all values are either 0 or binding): return the initial solution
   } else if (any(is.na(q))) {
-    
     if (discr$max_discr <= validation_tol) {
-      solve_msg_func("  Fixed balancing problem (all values are either 0 or binding) with a valid initial solution (maximum discrepancy <= ", 
-                     format(validation_tol), " = `validation_tol`).\n")
+      solve_msg_func(
+        "  Fixed balancing problem (all values are either 0 or binding) with a valid initial solution (maximum discrepancy <= ",
+        format(validation_tol), " = `validation_tol`).\n"
+      )
       status <- "valid initial solution"
       status_val <- 1
     } else {
-      warning("Unsolvable fixed balancing problem (all values are either 0 or binding) with an invalid initial solution (maximum discrepancy > ", 
-              format(validation_tol), " = `validation_tol`).", call. = FALSE, immediate. = TRUE)
+      warning("Unsolvable fixed balancing problem (all values are either 0 or binding) with an invalid initial solution (maximum discrepancy > ",
+        format(validation_tol), " = `validation_tol`).",
+        call. = FALSE, immediate. = TRUE
+      )
       message("\n")
       status <- "unsolvable fixed problem"
       status_val <- -4
@@ -2591,15 +2681,14 @@ solve_one_osqp <- function(x,
     osqp_info <- NULL
 
 
-  # At least one free (nonbinding) value: try to solve with OSQP
+    # At least one free (nonbinding) value: try to solve with OSQP
   } else {
-    
     # Note regarding flags `valid` and `satisfactory` used for the OSQP solving loop:
     #  - `valid`       : is TRUE if a valid solution (`max_discr <= validation_tol`) hasbeen found (initial or OSQP).
-    #  - `satisfactory`: is TRUE if a satisfactory OSQP solution (`valid & polished` when required, `valid` otherwise) 
+    #  - `satisfactory`: is TRUE if a satisfactory OSQP solution (`valid & polished` when required, `valid` otherwise)
     #                    has been found.
     #
-    # `satisfactory == TRUE` stops the solving loop (unless 'full_sequence == TRUE`); it is therefore initialized to 
+    # `satisfactory == TRUE` stops the solving loop (unless 'full_sequence == TRUE`); it is therefore initialized to
     # `FALSE` here (as we hope to improve the initial solution with OSQP).
     satisfactory <- FALSE
     if (discr$max_discr <= validation_tol) {
@@ -2617,42 +2706,43 @@ solve_one_osqp <- function(x,
     # Calculate the scaling factor
     mean_abs_x <- mean(abs(x))
 
-    
+
     # Solving loop
     best_osqp <- NA_integer_
     for (ii in seq_along(settings_df$verbose)) {
-
       # Set the scaling factor
       if (settings_df$prior_scaling[ii]) {
         factor_ii <- mean_abs_x
       } else {
         factor_ii <- 1
       }
-      
+
       osqpBeg_display_func(osqp_output_file)
 
       # Build the model (ii-th row of `settings_df`)
       model_ii <- osqp::osqp(P * factor_ii, q, A, l / factor_ii, u / factor_ii, as.list(settings_df[ii, , drop = FALSE]))
 
       # Solve
-      sol_ii <- model_ii$Solve() 
-      sol_ii$x <- sol_ii$x * factor_ii  # original scale
+      sol_ii <- model_ii$Solve()
+      sol_ii$x <- sol_ii$x * factor_ii # original scale
 
       osqpEnd_display_func(osqp_output_file)
 
       # Trunc to zero
       sol_ii$x[abs(sol_ii$x) <= trunc_to_zero_tol] <- 0
 
-      
+
       # Evaluate:
       #  a) update the "current solution" when relevant (smallest `tot_discr` among valid/invalid solutions so far)
       #  b) stop the solving loop if a satisfactory OSQP solution was found and not doing a full OSQP sequence
       Ax_ii <- A %*% sol_ii$x
       discr_ii <- calc_discr(Ax_ii, l, u)
       polished_ii <- sol_ii$info$status_polish == 1
-      solve_msg_func("  OSQP iteration ", ii, ":\n    - Maximum discrepancy = ", format(discr_ii$max_discr, big.mark = ","),
-                     "\n    - Total discrepancy   = ", format(discr_ii$tot_discr, big.mark = ","), "\n")
-      
+      solve_msg_func(
+        "  OSQP iteration ", ii, ":\n    - Maximum discrepancy = ", format(discr_ii$max_discr, big.mark = ","),
+        "\n    - Total discrepancy   = ", format(discr_ii$tot_discr, big.mark = ","), "\n"
+      )
+
       # Valid solution (`max_discr <= validation_tol`)
       if (discr_ii$max_discr <= validation_tol) {
         solve_msg_func("  Valid solution (maximum discrepancy <= ", format(validation_tol), " = `validation_tol`).\n")
@@ -2669,8 +2759,8 @@ solve_one_osqp <- function(x,
             status_ii <- "valid unpolished osqp solution"
             status_val_ii <- 3
           }
-          
-        # Polished solution NOT required
+
+          # Polished solution NOT required
         } else {
           satisfactory <- TRUE
           if (polished_ii) {
@@ -2681,7 +2771,7 @@ solve_one_osqp <- function(x,
             status_val_ii <- 3
           }
         }
-        
+
         # Update the "current (valid) solution"
         if (!valid || discr_ii$tot_discr < discr$tot_discr) {
           valid <- TRUE
@@ -2694,16 +2784,16 @@ solve_one_osqp <- function(x,
           sol <- sol_ii
           scaling_factor <- factor_ii
         }
-        
+
         # Stop the solving loop
         if (satisfactory && !full_sequence) {
           break
         }
-        
-      # Invalid solution (`max_discr > validation_tol`)
+
+        # Invalid solution (`max_discr > validation_tol`)
       } else {
         solve_msg_func("  Invalid solution (maximum discrepancy > ", format(validation_tol), " = `validation_tol`).\n")
-        
+
         # Update the "current (invalid) solution"
         if (!valid && discr_ii$tot_discr < discr$tot_discr) {
           if (polished_ii) {
@@ -2723,10 +2813,10 @@ solve_one_osqp <- function(x,
       }
     }
 
-    
-    # Wrap up the final solution    
+
+    # Wrap up the final solution
     osqp_attempts <- ii
-    
+
     # Initial solution
     if (is.na(best_osqp)) {
       solve_msg_func("  The initial solution could not be improved with OSQP. Returning the initial solution.\n")
@@ -2734,17 +2824,19 @@ solve_one_osqp <- function(x,
       osqp_seqno <- NA_integer_
       osqp_settings <- NULL
       osqp_info <- NULL
-      
-    # OSQP solution
+
+      # OSQP solution
     } else {
       if (!satisfactory) {
         if (valid) {
-          word <-  "valid"
+          word <- "valid"
         } else {
-          word <-  "all"
+          word <- "all"
         }
-        solve_msg_func("  A satisfactory OSQP solution could not be obtained. Returning the solution with the smallest ",
-                       "total discrepancy among ", word, " solutions (OSQP iteration ", best_osqp, ").\n")
+        solve_msg_func(
+          "  A satisfactory OSQP solution could not be obtained. Returning the solution with the smallest ",
+          "total discrepancy among ", word, " solutions (OSQP iteration ", best_osqp, ").\n"
+        )
       }
       x <- sol$x
       type <- "osqp"
@@ -2754,17 +2846,19 @@ solve_one_osqp <- function(x,
     }
   }
 
-    
+
   # Return the final solution
-  list(x = x,
-       status = status,
-       status_val = status_val,
-       Ax = Ax,
-       discr = discr,
-       type = type,
-       osqp_attempts = osqp_attempts,
-       osqp_seqno = osqp_seqno,
-       osqp_settings = osqp_settings,
-       osqp_info = osqp_info,
-       seq_time = Sys.time() - start_time)
+  list(
+    x = x,
+    status = status,
+    status_val = status_val,
+    Ax = Ax,
+    discr = discr,
+    type = type,
+    osqp_attempts = osqp_attempts,
+    osqp_seqno = osqp_seqno,
+    osqp_settings = osqp_settings,
+    osqp_info = osqp_info,
+    seq_time = Sys.time() - start_time
+  )
 }


### PR DESCRIPTION
`tsbalancing()` changes the option for `error` to `NULL`, despite the call to `on.exit()` that's supposed to leave the default error handler unchanged.

``` r
options(error = recover)
gseries::tsbalancing()
#> 
#> 
#> --- Package gseries 3.0.0 - (EN) 'G-Series' in 'R' / (FR) 'G-Séries' en 'R' ---
#> Created on April 30, 2025, at 4:57:41 PM EDT
#> URL: https://StatCan.github.io/gensol-gseries/en/
#>      https://StatCan.github.io/gensol-gseries/fr/
#> Email: g-series@statcan.gc.ca
#> 
#> tsbalancing() function:
#> Error: Argument 'in_ts' is mandatory (it must be specified).
#> NULL
getOption("error")
#> NULL
```

<sup>Created on 2025-06-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

With this patch the handler for errors only changes in the scope of the function.

``` r
options(error = recover)
gseries::tsbalancing()
#> 
#> 
#> --- Package gseries 3.0.0 - Tools for Cohesive Time Series Data ---
#> Created on April 30, 2025, at 4:57:41 PM EDT
#> URL: https://StatCan.github.io/gensol-gseries/en/
#>      https://StatCan.github.io/gensol-gseries/fr/
#> Email: g-series@statcan.gc.ca
#> 
#> tsbalancing() function:
#> Error: Argument 'in_ts' is mandatory (it must be specified).
#> NULL
getOption("error")
#> (function () 
#> {
#>     if (.isMethodsDispatchOn()) {
#>         tState <- tracingState(FALSE)
#>         on.exit(tracingState(tState))
#>     }
#>     calls <- sys.calls()
#>     from <- 0L
#>     n <- length(calls)
#>     if (identical(sys.function(n), recover)) 
#>         n <- n - 1L
#>     for (i in rev(seq_len(n))) {
#>         calli <- calls[[i]]
#>         fname <- calli[[1L]]
#>         if (!is.na(match(deparse(fname)[1L], c("methods::.doTrace", 
#>             ".doTrace")))) {
#>             from <- i - 1L
#>             break
#>         }
#>     }
#>     if (from == 0L) 
#>         for (i in rev(seq_len(n))) {
#>             calli <- calls[[i]]
#>             fname <- calli[[1L]]
#>             if (!is.name(fname) || is.na(match(as.character(fname), 
#>                 c("recover", "stop", "Stop")))) {
#>                 from <- i
#>                 break
#>             }
#>         }
#>     if (from > 0L) {
#>         if (!interactive()) {
#>             try(dump.frames())
#>             cat(gettext("recover called non-interactively; frames dumped, use debugger() to view\n"))
#>             return(NULL)
#>         }
#>         calls <- limitedLabels(calls[1L:from])
#>         repeat {
#>             which <- menu(calls, title = "\nEnter a frame number, or 0 to exit  ")
#>             if (which) 
#>                 eval(substitute(browser(skipCalls = skip), list(skip = 7 - 
#>                   which)), envir = sys.frame(which))
#>             else break
#>         }
#>     }
#>     else cat(gettext("No suitable frames for recover()\n"))
#> })()
```

<sup>Created on 2025-06-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I find it odd that this function (and several others) change the way error are handled. The comment in the code suggests it's to disable the traceback in rstudio, but I don't know why you'd want this. 